### PR TITLE
fix(php) - remove $ from constants

### DIFF
--- a/src/phpTranspiler.ts
+++ b/src/phpTranspiler.ts
@@ -103,8 +103,8 @@ export class PhpTranspiler extends BaseTranspiler {
 
         // below is commented, due to : https://github.com/ccxt/ast-transpiler/pull/15
         //
-        // // If the identifier is a function parameter (callback), it should remain a variable with `$` prefix
-        // if (node.parent && ts.isParameter(node.parent) || (node.parent && ts.isCallExpression(node.parent) && ts.isIdentifier(node))) {
+        // If the identifier is a function parameter (callback), it should remain a variable with `$` prefix
+        // if (node.parent && (ts.isParameter(node.parent) || (ts.isCallExpression(node.parent) && ts.isIdentifier(node)))) {
         //     return "$" + identifier;
         // }
 

--- a/src/phpTranspiler.ts
+++ b/src/phpTranspiler.ts
@@ -101,7 +101,8 @@ export class PhpTranspiler extends BaseTranspiler {
             }
         }
 
-        // below is commented, due to :
+        // below is commented, due to : https://github.com/ccxt/ast-transpiler/pull/15
+        //
         // // If the identifier is a function parameter (callback), it should remain a variable with `$` prefix
         // if (node.parent && ts.isParameter(node.parent) || (node.parent && ts.isCallExpression(node.parent) && ts.isIdentifier(node))) {
         //     return "$" + identifier;

--- a/src/phpTranspiler.ts
+++ b/src/phpTranspiler.ts
@@ -101,10 +101,11 @@ export class PhpTranspiler extends BaseTranspiler {
             }
         }
 
-        // If the identifier is a function parameter (callback), it should remain a variable with `$` prefix
-        if (node.parent && ts.isParameter(node.parent) || (node.parent && ts.isCallExpression(node.parent) && ts.isIdentifier(node))) {
-            return "$" + identifier;
-        }
+        // below is commented, due to :
+        // // If the identifier is a function parameter (callback), it should remain a variable with `$` prefix
+        // if (node.parent && ts.isParameter(node.parent) || (node.parent && ts.isCallExpression(node.parent) && ts.isIdentifier(node))) {
+        //     return "$" + identifier;
+        // }
 
         // Default case: prepend $ for variables (non-functions), unless it's a class or constant
         if (!this.startsWithUpperCase(identifier)) {

--- a/tests/phpTranspiler.test.ts
+++ b/tests/phpTranspiler.test.ts
@@ -836,6 +836,15 @@ describe('php transpiling tests', () => {
         const output = transpiler.transpilePhp(ts).content;
         expect(output).toBe(php);
     });
+    test.only('transpile constants & imports', () => {
+        const ts = "import { decimalToPrecision, ROUND, TRUNCATE, DECIMAL_PLACES, } from '../../somewhere.js';\n" +
+        "const exc = new xyz ();\n" +
+        "assert (exc.decimalToPrecision ('12.3456000', TRUNCATE, 100, DECIMAL_PLACES) === '12.3456');";
+        const php = "$exc = new xyz();\n" +
+        "assert($exc->decimalToPrecision('12.3456000', TRUNCATE, 100, DECIMAL_PLACES) === '12.3456');";
+        const output = transpiler.transpilePhp(ts).content;
+        expect(output).toBe(php);
+    });
     test('should transpile Number.isInteger', () => {
         const ts = "Number.isInteger(1)";
         const php = "is_int(1);";


### PR DESCRIPTION
I am not aware of the context of this change: https://github.com/ccxt/ast-transpiler/commit/34e762c9e4e87f1de36bda2d6fb080b04633c98a#diff-92b598f305823a81c60db0460aa7fe0e58d07143ddae06473b72e4de9ac5a524R103

however, if you transpile ccxt tests (REST & WS) with current astt (then commit locally), then comment out 103-105 lines and re-transpile, you will see that the only changes it does is to add `$` in front of constants like:

![image](https://github.com/user-attachments/assets/b4a8e345-5393-405e-909e-19c89c84c2f6)


only after this PR is merged, then review #14
