### PR TITLE
fix(go): correct struct generation

### DIFF
--- a/src/goTranspiler.ts
+++ b/src/goTranspiler.ts
@@ -221,7 +221,7 @@ export class GoTranspiler extends BaseTranspiler {
             tokens.push(heritageName);
         }
         const propDeclarations = node.members.filter(member => member.kind === SyntaxKind.PropertyDeclaration).map((member) => this.printNode(member, indentation + 1));
-        tokens = tokens.concat(propDeclarations)
+        tokens = tokens.concat(propDeclarations);
         tokens.push('}');
         return tokens.join('\n');
     }

--- a/src/goTranspiler.ts
+++ b/src/goTranspiler.ts
@@ -208,17 +208,22 @@ export class GoTranspiler extends BaseTranspiler {
 
     printStruct(node, indentation) {
         const className = node.name.escapedText;
+        let tokens = [
+            `type ${className} struct {`
+        ];
 
         // check if we have heritage
         let heritageName = '';
         if (node?.heritageClauses?.length > 0) {
             const heritage = node.heritageClauses[0];
             const heritageType = heritage.types[0];
-            heritageName = this.getIden(indentation+1) + heritageType.expression.escapedText + '\n';
+            heritageName = this.getIden(indentation+1) + heritageType.expression.escapedText;
+            tokens.push(heritageName);
         }
-
-        const propDeclarations = node.members.filter(member => member.kind === SyntaxKind.PropertyDeclaration);
-        return `type ${className} struct {\n${heritageName}${propDeclarations.map(member => this.printNode(member, indentation+1)).join("\n")}\n}`;
+        const propDeclarations = node.members.filter(member => member.kind === SyntaxKind.PropertyDeclaration).map((member) => this.printNode(member, indentation + 1));
+        tokens = tokens.concat(propDeclarations)
+        tokens.push('}');
+        return tokens.join('\n');
     }
 
     printNewStructMethod(node){

--- a/tests/goTranspiler.test.ts
+++ b/tests/goTranspiler.test.ts
@@ -51,7 +51,6 @@ describe('go transpiling tests', () => {
         "}";
         const go =
         "type Test struct {\n"+
-        "\n"+
         "}\n"+
         "\n"+
         "func NewTest() Test {\n"+
@@ -85,6 +84,30 @@ describe('go transpiling tests', () => {
         "if IsTrue(a) {\n" +
         "    var f interface{} = 1\n" +
         "}"
+        const output = transpiler.transpileGo(ts).content;
+        expect(output).toBe(go);
+    });
+    test('class extends declaration', () => {
+        const ts =
+        "class Toyota extends Car {\n" +
+        "    main() {\n" +
+        "        return 1\n" +
+        "    }\n" +
+        "}";
+        const go =
+        "type Toyota struct {\n"+
+        "    Car\n"+
+        "}\n"+
+        "\n"+
+        "func NewToyota() Toyota {\n"+
+        "   p := Toyota{}\n"+
+        "   setDefaults(&p)\n"+
+        "   return p\n"+
+        "}\n"+
+        "\n"+
+        "func  (this *Toyota) Main() interface{}  {\n"+
+        "    return 1\n"+
+        "}";
         const output = transpiler.transpileGo(ts).content;
         expect(output).toBe(go);
     });


### PR DESCRIPTION
IMHO, the struct should look like this.

```GO
# empty props
type Car struct {
}

# inherit car
type Toyota struct {
    Car
}

# with properties
type Toyota struct {
    Car
    Weight int64
    Height int64
    Speed int64
}
```

In this PR, I fixed the generation procedure for struct in GO.