### PR TITLE
fix(java): handle PrefixUnaryExpression in object-literal var substitution

### DIFF
--- a/src/javaTranspiler.ts
+++ b/src/javaTranspiler.ts
@@ -773,6 +773,36 @@ export class JavaTranspiler extends BaseTranspiler {
             return this.varListFromObjectLiterals[nodeId];
         }
 
+        // shared helper: walks an expression and replaces identifiers of
+        // reassigned variables with their finalXxx counterparts in place.
+        const traverseAndReplace = (n) => {
+            if (!n) return;
+            if (n.kind === ts.SyntaxKind.Identifier && n.escapedText !== 'undefined' && !n.escapedText?.startsWith('null')) {
+                if (this.ReassignedVars[this.getVarKey(n)]) {
+                    res.push(n.escapedText);
+                    n.escapedText = this.getFinalVarName(n.escapedText);
+                }
+                return;
+            }
+            if (n.kind === ts.SyntaxKind.BinaryExpression) {
+                traverseAndReplace(n.left);
+                traverseAndReplace(n.right);
+            } else if (n.kind === ts.SyntaxKind.ParenthesizedExpression) {
+                traverseAndReplace(n.expression);
+            } else if (n.kind === ts.SyntaxKind.ConditionalExpression) {
+                traverseAndReplace(n.condition);
+                traverseAndReplace(n.whenTrue);
+                traverseAndReplace(n.whenFalse);
+            } else if (n.kind === ts.SyntaxKind.CallExpression) {
+                n.arguments?.forEach(arg => traverseAndReplace(arg));
+                if (n.expression?.kind === ts.SyntaxKind.PropertyAccessExpression) {
+                    traverseAndReplace(n.expression.expression);
+                }
+            } else if (n.kind === ts.SyntaxKind.PrefixUnaryExpression) {
+                traverseAndReplace(n.operand);
+            }
+        };
+
         node.properties.forEach( (prop) => {
             if (prop.initializer?.kind === ts.SyntaxKind.Identifier && prop.initializer.escapedText !== 'undefined' && !prop.initializer.escapedText.startsWith('null')) {
                 // if (this.ReassignedVars[prop.initializer.escapedText]) {
@@ -902,38 +932,14 @@ export class JavaTranspiler extends BaseTranspiler {
             }
             else if (prop.initializer?.kind === ts.SyntaxKind.ConditionalExpression) {
                 // handle ternary: (type === 'swap') ? true : undefined
-                // Traverse the condition/whenTrue/whenFalse and replace identifiers in place
-                const traverseAndReplace = (node) => {
-                    if (!node) return;
-                    if (node.kind === ts.SyntaxKind.Identifier && node.escapedText !== 'undefined' && !node.escapedText?.startsWith('null')) {
-                        if (this.ReassignedVars[this.getVarKey(node)]) {
-                            res.push(node.escapedText);
-                            node.escapedText = this.getFinalVarName(node.escapedText);
-                        }
-                        return;
-                    }
-                    if (node.kind === ts.SyntaxKind.BinaryExpression) {
-                        traverseAndReplace(node.left);
-                        traverseAndReplace(node.right);
-                    } else if (node.kind === ts.SyntaxKind.ParenthesizedExpression) {
-                        traverseAndReplace(node.expression);
-                    } else if (node.kind === ts.SyntaxKind.ConditionalExpression) {
-                        traverseAndReplace(node.condition);
-                        traverseAndReplace(node.whenTrue);
-                        traverseAndReplace(node.whenFalse);
-                    } else if (node.kind === ts.SyntaxKind.CallExpression) {
-                        node.arguments?.forEach(arg => traverseAndReplace(arg));
-                        if (node.expression?.kind === ts.SyntaxKind.PropertyAccessExpression) {
-                            traverseAndReplace(node.expression.expression);
-                        }
-                    } else if (node.kind === ts.SyntaxKind.PrefixUnaryExpression) {
-                        traverseAndReplace(node.operand);
-                    }
-                };
                 const cond = prop.initializer;
                 traverseAndReplace(cond.condition);
                 traverseAndReplace(cond.whenTrue);
                 traverseAndReplace(cond.whenFalse);
+            }
+            else if (prop.initializer?.kind === ts.SyntaxKind.PrefixUnaryExpression) {
+                // handle prefix unary: !isSpot, -count, !(a && b), !foo.bar()
+                traverseAndReplace(prop.initializer.operand);
             }
             else if (prop.initializer?.kind === ts.SyntaxKind.ObjectLiteralExpression) {
                 const innerVars = this.getVarListFromObjectLiteralAndUpdateInPlace(prop.initializer);

--- a/src/javaTranspiler.ts
+++ b/src/javaTranspiler.ts
@@ -672,6 +672,37 @@ export class JavaTranspiler extends BaseTranspiler {
         return res;
     }
 
+    // Finds every ObjectLiteralExpression nested anywhere inside an RHS/initializer
+    // expression that would produce an anonymous-inner-class capture in Java
+    // (HashMap double-brace init). Stops descending at each ObjectLiteralExpression
+    // because nested literals are walked recursively inside
+    // getVarListFromObjectLiteralAndUpdateInPlace. Skips function/arrow bodies so
+    // we don't capture literals that evaluate in a different scope.
+    //
+    // Unifies the previously-narrow matching in printVariableDeclarationList and
+    // getBinaryExpressionPrefixes which only handled ObjectLiteralExpression or
+    // CallExpression directly — missing wrappers like AwaitExpression,
+    // ParenthesizedExpression, NewExpression, and ConditionalExpression.
+    collectCapturingObjectLiterals(node): any[] {
+        const found = [];
+        const walk = (n) => {
+            if (!n) return;
+            if (n.kind === ts.SyntaxKind.ObjectLiteralExpression) {
+                found.push(n);
+                return;
+            }
+            if (n.kind === ts.SyntaxKind.FunctionExpression ||
+                n.kind === ts.SyntaxKind.ArrowFunction ||
+                n.kind === ts.SyntaxKind.MethodDeclaration ||
+                n.kind === ts.SyntaxKind.FunctionDeclaration) {
+                return;
+            }
+            ts.forEachChild(n, walk);
+        };
+        walk(node);
+        return found;
+    }
+
     getBinaryExpressionPrefixes(node, identation) {
         let right = node?.right;
         if (right?.kind === ts.SyntaxKind.AwaitExpression) {
@@ -1070,20 +1101,16 @@ export class JavaTranspiler extends BaseTranspiler {
         const declaration = node.declarations[0];
 
         let finalVars = '';
-        if (declaration.initializer?.kind === ts.SyntaxKind.ObjectLiteralExpression) {
-            // iterator over object and collect variables
-            const varsList = this.getVarListFromObjectLiteralAndUpdateInPlace(declaration.initializer);
-            finalVars = this.buildFinalVarDeclarations(varsList, identation);
-        } else if (declaration.initializer?.kind === ts.SyntaxKind.CallExpression) {
-            const callExp = declaration.initializer;
-            const args = callExp.arguments ?? [];
+        if (declaration.initializer) {
+            // Walk the whole initializer tree — handles AwaitExpression,
+            // ParenthesizedExpression, NewExpression, ConditionalExpression,
+            // nested CallExpressions, etc. uniformly.
+            const objLiterals = this.collectCapturingObjectLiterals(declaration.initializer);
             let varObj = [];
-            args.forEach( (arg) => {
-                if (arg.kind === ts.SyntaxKind.ObjectLiteralExpression) {
-                    const objVariables = this.getVarListFromObjectLiteralAndUpdateInPlace(arg);
-                    varObj = varObj.concat(objVariables);
-                }
-            });
+            for (const lit of objLiterals) {
+                const vars = this.getVarListFromObjectLiteralAndUpdateInPlace(lit);
+                varObj = varObj.concat(vars);
+            }
             if (varObj.length > 0) {
                 finalVars = this.buildFinalVarDeclarations(varObj, identation);
             }

--- a/src/javaTranspiler.ts
+++ b/src/javaTranspiler.ts
@@ -1016,151 +1016,41 @@ export class JavaTranspiler extends BaseTranspiler {
             return this.usageToFinalName.get(n) ?? this.getFinalVarName(origName);
         };
 
+        // Walks any expression, rewriting reassigned-var Identifiers to their
+        // finalXxx names in place. We rely on ts.forEachChild for traversal so
+        // every node kind (PrefixUnary, PostfixUnary, ElementAccess,
+        // PropertyAccess, BinaryExpression, ConditionalExpression, CallExpression,
+        // ParenthesizedExpression, etc.) is covered uniformly. ObjectLiteral is
+        // delegated back to the parent function so per-objectLiteral nodeId
+        // dedup applies to nested literals too.
         const traverseAndReplace = (n) => {
             if (!n) return;
-            if (n.kind === ts.SyntaxKind.Identifier && n.escapedText !== 'undefined' && !n.escapedText?.startsWith('null')) {
-                if (this.ReassignedVars[this.getVarKey(n)]) {
-                    const orig = n.escapedText as string;
-                    const finalName = finalNameFor(n, orig);
-                    res.push({ orig, final: finalName });
-                    n.escapedText = finalName;
+            if (n.kind === ts.SyntaxKind.Identifier) {
+                const name = n.escapedText as string | undefined;
+                if (name && name !== 'undefined' && !name.startsWith('null')) {
+                    if (this.ReassignedVars[this.getVarKey(n)]) {
+                        const finalName = finalNameFor(n, name);
+                        res.push({ orig: name, final: finalName });
+                        n.escapedText = finalName;
+                        // Some downstream print paths read from getFullText (which
+                        // reflects the source text, not escapedText) — shim it so
+                        // they see the rewritten name.
+                        (n as any).getFullText = () => finalName;
+                    }
                 }
                 return;
             }
-            if (n.kind === ts.SyntaxKind.BinaryExpression) {
-                traverseAndReplace(n.left);
-                traverseAndReplace(n.right);
-            } else if (n.kind === ts.SyntaxKind.ParenthesizedExpression) {
-                traverseAndReplace(n.expression);
-            } else if (n.kind === ts.SyntaxKind.ConditionalExpression) {
-                traverseAndReplace(n.condition);
-                traverseAndReplace(n.whenTrue);
-                traverseAndReplace(n.whenFalse);
-            } else if (n.kind === ts.SyntaxKind.CallExpression) {
-                n.arguments?.forEach(arg => traverseAndReplace(arg));
-                if (n.expression?.kind === ts.SyntaxKind.PropertyAccessExpression) {
-                    traverseAndReplace(n.expression.expression);
-                }
-            } else if (n.kind === ts.SyntaxKind.PrefixUnaryExpression) {
-                traverseAndReplace(n.operand);
+            if (n.kind === ts.SyntaxKind.ObjectLiteralExpression) {
+                const innerVars = this.getVarListFromObjectLiteralAndUpdateInPlace(n);
+                res = res.concat(innerVars);
+                return;
             }
+            ts.forEachChild(n, traverseAndReplace);
         };
 
         node.properties.forEach( (prop) => {
-            if (prop.initializer?.kind === ts.SyntaxKind.Identifier && prop.initializer.escapedText !== 'undefined' && !prop.initializer.escapedText.startsWith('null')) {
-                if (this.ReassignedVars[this.getVarKey(prop.initializer)]) {
-                    const orig = prop.initializer.escapedText as string;
-                    const finalName = finalNameFor(prop.initializer, orig);
-                    res.push({ orig, final: finalName });
-                    const newNode = ts.factory.createIdentifier(finalName);
-                    prop.initializer = newNode;
-                }
-            } else if (prop.initializer?.kind === ts.SyntaxKind.CallExpression) {
-                const callExp = prop.initializer;
-                const transverseCallExpressionArguments = (callExpression) => {
-                    callExpression.arguments.forEach( (arg, i) => {
-                        if (arg.kind === ts.SyntaxKind.Identifier) {
-                            if (this.ReassignedVars[this.getVarKey(arg)]) {
-                                const orig = arg.escapedText as string;
-                                const finalName = finalNameFor(arg, orig);
-                                res.push({ orig, final: finalName });
-                                const newNode = ts.factory.createIdentifier(finalName);
-                                (newNode as any).getFullText = () => finalName;
-                                callExpression.arguments[i] = newNode;
-                            }
-                        } else if (arg.kind === ts.SyntaxKind.CallExpression) {
-                            transverseCallExpressionArguments(arg);
-                        }
-                    });
-                };
-
-                transverseCallExpressionArguments(callExp);
-
-                // handle side.toUpperCase() scenarios
-                if (callExp.expression?.kind === ts.SyntaxKind.PropertyAccessExpression) {
-                    const propAccess = callExp.expression;
-                    const leftSide = propAccess.expression;
-                    if (leftSide.kind === ts.SyntaxKind.Identifier) {
-                        if (this.ReassignedVars[this.getVarKey(leftSide)]) {
-                            const orig = leftSide.escapedText as string;
-                            const finalName = finalNameFor(leftSide, orig);
-                            res.push({ orig, final: finalName });
-                            const newNode = ts.factory.createIdentifier(finalName);
-                            (newNode as any).getFullText = () => finalName;
-                            leftSide.escapedText = newNode.escapedText;
-                            propAccess.expression = newNode;
-                        }
-                    }
-                }
-            } else if (prop.initializer?.kind === ts.SyntaxKind.BinaryExpression) {
-                // handle scenarios like : 'a': b + b +x
-                const binExp = prop.initializer;
-                const checkNode = (n) => {
-                    if (!n) {
-                        return n;
-                    }
-                    if (n.kind === ts.SyntaxKind.Identifier) {
-                        if (this.ReassignedVars[this.getVarKey(n)]) {
-                            const orig = n.escapedText as string;
-                            const finalName = finalNameFor(n, orig);
-                            res.push({ orig, final: finalName });
-                            const newNode = ts.factory.createIdentifier(finalName);
-                            (newNode as any).getFullText = () => finalName;
-                            return newNode;
-                        }
-                    }
-                    return n;
-                };
-                const traverseBinaryExpression = (be) => {
-                    be.left = checkNode(be.left);
-                    be.right = checkNode(be.right);
-                    if (be?.left?.kind === ts.SyntaxKind.BinaryExpression) {
-                        traverseBinaryExpression(be.left);
-                    }
-                    if (be?.right?.kind === ts.SyntaxKind.BinaryExpression) {
-                        traverseBinaryExpression(be.right);
-                    }
-                };
-                traverseBinaryExpression(binExp);
-
-            } else if (prop.initializer?.kind === ts.SyntaxKind.ElementAccessExpression) {
-                let left = prop.initializer.expression;
-                const right = prop.initializer.argumentExpression;
-                if (left.kind === ts.SyntaxKind.ElementAccessExpression) {
-                    while (left.kind === ts.SyntaxKind.ElementAccessExpression) {
-                        left = left.expression;
-                    }
-                }
-                if (this.ReassignedVars[this.getVarKey(left)]) {
-                    const orig = left.escapedText as string;
-                    const finalName = finalNameFor(left, orig);
-                    left.escapedText = finalName;
-                    res.push({ orig, final: finalName });
-                }
-                if (right.kind === ts.SyntaxKind.Identifier) {
-                    if (this.ReassignedVars[this.getVarKey(right)]) {
-                        const orig = right.escapedText as string;
-                        const finalName = finalNameFor(right, orig);
-                        right.escapedText = finalName;
-                        res.push({ orig, final: finalName });
-                    }
-                }
-            }
-            else if (prop.initializer?.kind === ts.SyntaxKind.ConditionalExpression) {
-                // handle ternary: (type === 'swap') ? true : undefined
-                const cond = prop.initializer;
-                traverseAndReplace(cond.condition);
-                traverseAndReplace(cond.whenTrue);
-                traverseAndReplace(cond.whenFalse);
-            }
-            else if (prop.initializer?.kind === ts.SyntaxKind.PrefixUnaryExpression) {
-                // handle prefix unary: !isSpot, -count, !(a && b), !foo.bar()
-                traverseAndReplace(prop.initializer.operand);
-            }
-            else if (prop.initializer?.kind === ts.SyntaxKind.ObjectLiteralExpression) {
-                const innerVars = this.getVarListFromObjectLiteralAndUpdateInPlace(prop.initializer);
-                res = res.concat(innerVars);
-            }
+            if (!prop.initializer) return;
+            traverseAndReplace(prop.initializer);
         });
 
         // dedup on (orig|final) pair
@@ -1417,9 +1307,6 @@ export class JavaTranspiler extends BaseTranspiler {
 
         }
         return blockOpen + firstStatement + remainingString + blockClose;
-        // }
-
-        return super.printFunctionBody(node, identation);
     }
 
     printBlock(node, identation, chainBlock = false) {

--- a/src/javaTranspiler.ts
+++ b/src/javaTranspiler.ts
@@ -72,9 +72,13 @@ export class JavaTranspiler extends BaseTranspiler {
     binaryExpressionsWrappers;
 
     varListFromObjectLiterals = {};
-    emittedFinalVars: Set<string> = new Set();
-    pendingFinalVars: Array<{orig: string, final: string}> = [];
-    methodBodyVarNames: Set<string> = new Set();
+    // Per-function analysis results. Populated by analyzeFinalVars at the start of
+    // printFunctionBody and consumed during printing of the same function body.
+    usageToFinalName: WeakMap<ts.Node, string> = new WeakMap();
+    // Stack of emitted-finalName sets, one entry per enclosing block. Pushed on block
+    // entry, popped on exit. Used by buildFinalVarDeclarations to dedup: skip if the
+    // finalName is already in scope via any ancestor.
+    finalVarScopeStack: Array<Set<string>> = [];
 
     constructor(config = {}) {
         config["parser"] = Object.assign({}, parserConfig, config["parser"] ?? {});
@@ -724,29 +728,262 @@ export class JavaTranspiler extends BaseTranspiler {
         return name;
     }
 
-    buildFinalVarDeclarations(varNames: string[], identation: number): string {
-        const inlineVars = [];
-        for (const v of varNames) {
-            const finalName = this.getFinalVarName(v);
-            const origName = this.getOriginalVarName(v);
-            if (this.methodBodyVarNames.has(origName)) {
-                // Variable is declared at method body level — hoist (deduplicate across method)
-                if (!this.emittedFinalVars.has(finalName)) {
-                    this.emittedFinalVars.add(finalName);
-                    this.pendingFinalVars.push({ orig: origName, final: finalName });
+    // Resolves the trio of names used to wrap a reassigned async-method param
+    // so the lambda body sees an effectively-final local. We base every name on
+    // the keyword-remapped Java identifier — using the raw TS name when remapped
+    // (e.g. params -> parameters) makes the wrapper text and the body diverge,
+    // because identifier emission already routes through ReservedKeywordsReplacements.
+    private getAsyncParamWrapperNames(paramName: string): { sigName: string; snapName: string; localName: string } {
+        const javaName = this.getOriginalVarName(paramName);
+        return {
+            sigName: `${javaName}2`,
+            snapName: `${javaName}3`,
+            localName: javaName,
+        };
+    }
+
+    private isAssignmentOperator(op: ts.SyntaxKind): boolean {
+        return op === ts.SyntaxKind.EqualsToken ||
+            op === ts.SyntaxKind.PlusEqualsToken ||
+            op === ts.SyntaxKind.MinusEqualsToken ||
+            op === ts.SyntaxKind.AsteriskEqualsToken ||
+            op === ts.SyntaxKind.AsteriskAsteriskEqualsToken ||
+            op === ts.SyntaxKind.SlashEqualsToken ||
+            op === ts.SyntaxKind.PercentEqualsToken ||
+            op === ts.SyntaxKind.LessThanLessThanEqualsToken ||
+            op === ts.SyntaxKind.GreaterThanGreaterThanEqualsToken ||
+            op === ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken ||
+            op === ts.SyntaxKind.AmpersandEqualsToken ||
+            op === ts.SyntaxKind.BarEqualsToken ||
+            op === ts.SyntaxKind.CaretEqualsToken ||
+            op === ts.SyntaxKind.BarBarEqualsToken ||
+            op === ts.SyntaxKind.AmpersandAmpersandEqualsToken ||
+            op === ts.SyntaxKind.QuestionQuestionEqualsToken;
+    }
+
+    private isIncDecOperator(op: ts.SyntaxKind): boolean {
+        return op === ts.SyntaxKind.PlusPlusToken || op === ts.SyntaxKind.MinusMinusToken;
+    }
+
+    // Walk the function body in source order and assign a version-aware finalName to
+    // every identifier that appears inside an object literal property and refers to a
+    // variable that's reassigned anywhere in this function. Each reassignment bumps the
+    // per-variable version counter; usages of the same (var, version) share one finalName.
+    //
+    // Naming:
+    //   - If only one version of a var is ever used in object literals, use `final<Var>`
+    //     (matches prior behavior).
+    //   - If multiple versions are used, name them `final<Var>`, `final<Var>_2`,
+    //     `final<Var>_3` in source-order of the version they correspond to.
+    analyzeFinalVars(fnBody: ts.Node): void {
+        this.usageToFinalName = new WeakMap();
+        if (!fnBody) return;
+
+        // Symbol identity: two identifiers are the same lexical variable iff they
+        // resolve to the same declaration. This differentiates e.g. `i` in two
+        // sibling for-loops (separate `let i` declarations = separate symbols).
+        const symbolIdOf = (n: any): string => {
+            try {
+                const checker = (global as any).checker;
+                const sym = checker?.getSymbolAtLocation?.(n);
+                const decl = sym?.declarations?.[0] ?? sym?.valueDeclaration;
+                if (decl) return `s:${decl.pos}:${decl.end}`;
+            } catch {
+                // checker may be unavailable in some contexts — fall through to name-based id
+            }
+            return `n:${n.escapedText}`;
+        };
+
+        // Pass 1 — discover which symbols are reassigned anywhere in this function body.
+        const reassignedSyms = new Set<string>();
+        const discoverWalk = (node: any) => {
+            if (!node) return;
+            if (node.kind === ts.SyntaxKind.BinaryExpression &&
+                this.isAssignmentOperator(node.operatorToken.kind) &&
+                node.left?.kind === ts.SyntaxKind.Identifier) {
+                reassignedSyms.add(symbolIdOf(node.left));
+            }
+            if ((node.kind === ts.SyntaxKind.PrefixUnaryExpression ||
+                 node.kind === ts.SyntaxKind.PostfixUnaryExpression) &&
+                this.isIncDecOperator(node.operator) &&
+                node.operand?.kind === ts.SyntaxKind.Identifier) {
+                reassignedSyms.add(symbolIdOf(node.operand));
+            }
+            ts.forEachChild(node, discoverWalk);
+        };
+        discoverWalk(fnBody);
+
+        if (reassignedSyms.size === 0) return;
+
+        // Pass 2 — walk in source order, producing a stream of reassignment and usage
+        // events keyed by symbol. Usages are identifiers that (a) sit inside an
+        // object literal property initializer expression, (b) refer to a reassigned symbol.
+        type Event =
+            | { kind: 'reassign'; sym: string }
+            | { kind: 'use'; sym: string; name: string; node: ts.Node };
+        const events: Event[] = [];
+
+        const visitExprInObjLit = (n: any) => {
+            if (!n) return;
+            if (n.kind === ts.SyntaxKind.Identifier) {
+                const name = n.escapedText as string;
+                if (name && name !== 'undefined' && !name.startsWith?.('null')) {
+                    const sym = symbolIdOf(n);
+                    if (reassignedSyms.has(sym)) {
+                        events.push({ kind: 'use', sym, name, node: n });
+                    }
                 }
+                return;
+            }
+            if (n.kind === ts.SyntaxKind.BinaryExpression) {
+                visitExprInObjLit(n.left);
+                visitExprInObjLit(n.right);
+                return;
+            }
+            if (n.kind === ts.SyntaxKind.ParenthesizedExpression) {
+                visitExprInObjLit(n.expression);
+                return;
+            }
+            if (n.kind === ts.SyntaxKind.ConditionalExpression) {
+                visitExprInObjLit(n.condition);
+                visitExprInObjLit(n.whenTrue);
+                visitExprInObjLit(n.whenFalse);
+                return;
+            }
+            if (n.kind === ts.SyntaxKind.CallExpression) {
+                n.arguments?.forEach(visitExprInObjLit);
+                if (n.expression?.kind === ts.SyntaxKind.PropertyAccessExpression) {
+                    visitExprInObjLit(n.expression.expression);
+                }
+                return;
+            }
+            if (n.kind === ts.SyntaxKind.PrefixUnaryExpression) {
+                visitExprInObjLit(n.operand);
+                return;
+            }
+            if (n.kind === ts.SyntaxKind.ElementAccessExpression) {
+                let left = n.expression;
+                while (left?.kind === ts.SyntaxKind.ElementAccessExpression) {
+                    left = left.expression;
+                }
+                visitExprInObjLit(left);
+                visitExprInObjLit(n.argumentExpression);
+                return;
+            }
+            if (n.kind === ts.SyntaxKind.ObjectLiteralExpression) {
+                n.properties?.forEach((p: any) => {
+                    if (p.initializer) visitExprInObjLit(p.initializer);
+                });
+                return;
+            }
+            // Other shapes (property access, literals, etc.) — ignore.
+        };
+
+        const walk = (node: any) => {
+            if (!node) return;
+
+            if (node.kind === ts.SyntaxKind.BinaryExpression &&
+                this.isAssignmentOperator(node.operatorToken.kind)) {
+                walk(node.right);
+                if (node.left?.kind === ts.SyntaxKind.Identifier) {
+                    const sym = symbolIdOf(node.left);
+                    if (reassignedSyms.has(sym)) {
+                        events.push({ kind: 'reassign', sym });
+                    }
+                } else {
+                    walk(node.left);
+                }
+                return;
+            }
+
+            if ((node.kind === ts.SyntaxKind.PrefixUnaryExpression ||
+                 node.kind === ts.SyntaxKind.PostfixUnaryExpression) &&
+                this.isIncDecOperator(node.operator) &&
+                node.operand?.kind === ts.SyntaxKind.Identifier) {
+                const sym = symbolIdOf(node.operand);
+                if (reassignedSyms.has(sym)) {
+                    events.push({ kind: 'reassign', sym });
+                }
+                return;
+            }
+
+            if (node.kind === ts.SyntaxKind.ObjectLiteralExpression) {
+                node.properties?.forEach((prop: any) => {
+                    if (prop.initializer) {
+                        visitExprInObjLit(prop.initializer);
+                        walk(prop.initializer);
+                    }
+                });
+                return;
+            }
+
+            ts.forEachChild(node, walk);
+        };
+
+        walk(fnBody);
+
+        // Post-process: compute per-symbol versions and assign final names. The
+        // final name is derived from the identifier's text, not the symbol — so
+        // two distinct symbols named `i` both get `finalI` (each lives in its own
+        // lexical scope, so scope-stack dedup allows both to be emitted).
+        const counters = new Map<string, number>();
+        const perSym = new Map<string, { name: string; byVer: Map<number, ts.Node[]> }>();
+        for (const e of events) {
+            if (e.kind === 'reassign') {
+                counters.set(e.sym, (counters.get(e.sym) ?? 0) + 1);
             } else {
-                // Variable is local to a nested block (loop/if) — emit inline
-                // No dedup: each block scope (e.g., separate for-loops) needs its own declaration
-                inlineVars.push(v);
+                const v = counters.get(e.sym) ?? 0;
+                if (!perSym.has(e.sym)) perSym.set(e.sym, { name: e.name, byVer: new Map() });
+                const entry = perSym.get(e.sym)!;
+                if (!entry.byVer.has(v)) entry.byVer.set(v, []);
+                entry.byVer.get(v)!.push(e.node);
             }
         }
-        if (inlineVars.length === 0) {
-            return '';
+
+        for (const { name, byVer } of perSym.values()) {
+            const versions = [...byVer.keys()].sort((a, b) => a - b);
+            const baseName = this.getFinalVarName(name);
+            if (versions.length === 1) {
+                for (const n of byVer.get(versions[0])!) {
+                    this.usageToFinalName.set(n, baseName);
+                }
+            } else {
+                versions.forEach((v, idx) => {
+                    const finalName = idx === 0 ? baseName : `${baseName}_${idx + 1}`;
+                    for (const n of byVer.get(v)!) {
+                        this.usageToFinalName.set(n, finalName);
+                    }
+                });
+            }
         }
-        return inlineVars.map((v, i) =>
-            `${this.getIden(i > 0 ? identation : 0)}final Object ${this.getFinalVarName(v)} = ${this.getOriginalVarName(v)};`
-        ).join('\n');
+    }
+
+    private finalNameInAncestorScope(finalName: string): boolean {
+        for (const scope of this.finalVarScopeStack) {
+            if (scope.has(finalName)) return true;
+        }
+        return false;
+    }
+
+    buildFinalVarDeclarations(pairs: Array<{ orig: string; final: string }>, identation: number): string {
+        if (pairs.length === 0) return '';
+        const current = this.finalVarScopeStack.length > 0
+            ? this.finalVarScopeStack[this.finalVarScopeStack.length - 1]
+            : null;
+        const lines: string[] = [];
+        const seenHere = new Set<string>();
+        for (const p of pairs) {
+            if (seenHere.has(p.final)) continue;
+            if (this.finalNameInAncestorScope(p.final)) continue;
+            seenHere.add(p.final);
+            if (current) current.add(p.final);
+            const indent = lines.length === 0 ? 0 : identation;
+            // The RHS must use the remapped Java name (e.g. `params` → `parameters`,
+            // `internal` → `intern`) since the original TS identifier doesn't exist
+            // in the generated Java code.
+            lines.push(`${this.getIden(indent)}final Object ${p.final} = ${this.getOriginalVarName(p.orig)};`);
+        }
+        return lines.join('\n');
     }
 
     getObjectLiteralId(node): string {
@@ -761,11 +998,13 @@ export class JavaTranspiler extends BaseTranspiler {
         return newNode;
     }
 
-    getVarListFromObjectLiteralAndUpdateInPlace(node): string[] {
+    getVarListFromObjectLiteralAndUpdateInPlace(node): Array<{ orig: string; final: string }> {
         // in java if we use an anonymous object literal put, we can't refer non final variables
         // so here we collect them and then we add the wrapper final variables, eg: finalX = X;
-        // and we update the node in place to use finalX instead of X
-        let res = [];
+        // and we update the node in place to use finalX instead of X.
+        // The final name comes from analyzeFinalVars (pre-walk), which assigns
+        // version-aware names so reassignment-between-usages produces distinct finals.
+        let res: Array<{ orig: string; final: string }> = [];
 
         const nodeId = this.getObjectLiteralId(node);
 
@@ -773,14 +1012,18 @@ export class JavaTranspiler extends BaseTranspiler {
             return this.varListFromObjectLiterals[nodeId];
         }
 
-        // shared helper: walks an expression and replaces identifiers of
-        // reassigned variables with their finalXxx counterparts in place.
+        const finalNameFor = (n: any, origName: string): string => {
+            return this.usageToFinalName.get(n) ?? this.getFinalVarName(origName);
+        };
+
         const traverseAndReplace = (n) => {
             if (!n) return;
             if (n.kind === ts.SyntaxKind.Identifier && n.escapedText !== 'undefined' && !n.escapedText?.startsWith('null')) {
                 if (this.ReassignedVars[this.getVarKey(n)]) {
-                    res.push(n.escapedText);
-                    n.escapedText = this.getFinalVarName(n.escapedText);
+                    const orig = n.escapedText as string;
+                    const finalName = finalNameFor(n, orig);
+                    res.push({ orig, final: finalName });
+                    n.escapedText = finalName;
                 }
                 return;
             }
@@ -805,54 +1048,28 @@ export class JavaTranspiler extends BaseTranspiler {
 
         node.properties.forEach( (prop) => {
             if (prop.initializer?.kind === ts.SyntaxKind.Identifier && prop.initializer.escapedText !== 'undefined' && !prop.initializer.escapedText.startsWith('null')) {
-                // if (this.ReassignedVars[prop.initializer.escapedText]) {
                 if (this.ReassignedVars[this.getVarKey(prop.initializer)]) {
-                    res.push(prop.initializer.escapedText);
-                    const finalName = this.getFinalVarName(prop.initializer.escapedText);
+                    const orig = prop.initializer.escapedText as string;
+                    const finalName = finalNameFor(prop.initializer, orig);
+                    res.push({ orig, final: finalName });
                     const newNode = ts.factory.createIdentifier(finalName);
                     prop.initializer = newNode;
                 }
             } else if (prop.initializer?.kind === ts.SyntaxKind.CallExpression) {
-                // check if any of the args is an identifier that was reassigned
-                const callArgs = prop.initializer?.arguments ?? [];
                 const callExp = prop.initializer;
-                // transverseCallExpressionArguments(callExp);
-                // callArgs.forEach( (arg,i) => {
-                //     if (arg.kind === ts.SyntaxKind.Identifier) {
-                //         // if (this.ReassignedVars[arg.escapedText]) {
-                //         if (this.ReassignedVars[this.getVarKey(arg)]) {
-                //             res.push(arg.escapedText);
-                //             const newNode = this.createNewNodeForFinalVar(arg.escapedText);
-                //             arg = newNode;
-                //             callExp.arguments[i] = newNode;
-                //         }
-                //     } else if (arg.kind === ts.SyntaxKind.CallExpression) {
-                //         const innerCallExp = arg;
-                //         innerCallExp.arguments.forEach( (innerArg,j) => {
-                //             if (innerArg.kind === ts.SyntaxKind.Identifier) {
-                //                 if (this.ReassignedVars[this.getVarKey(innerArg)]) {
-                //                     res.push(innerArg.escapedText);
-                //                     const newNode = this.createNewNodeForFinalVar(innerArg.escapedText);
-                //                     innerArg = newNode;
-                //                     innerCallExp.arguments[j] = newNode;
-                //                 }
-                //             }
-                //         });
-                //     }
-                // });
-
                 const transverseCallExpressionArguments = (callExpression) => {
                     callExpression.arguments.forEach( (arg, i) => {
                         if (arg.kind === ts.SyntaxKind.Identifier) {
                             if (this.ReassignedVars[this.getVarKey(arg)]) {
-                                res.push(arg.escapedText);
-                                const newNode = this.createNewNodeForFinalVar(arg.escapedText);
-                                arg = newNode;
+                                const orig = arg.escapedText as string;
+                                const finalName = finalNameFor(arg, orig);
+                                res.push({ orig, final: finalName });
+                                const newNode = ts.factory.createIdentifier(finalName);
+                                (newNode as any).getFullText = () => finalName;
                                 callExpression.arguments[i] = newNode;
                             }
                         } else if (arg.kind === ts.SyntaxKind.CallExpression) {
-                            const innerCallExp = arg;
-                            transverseCallExpressionArguments(innerCallExp);
+                            transverseCallExpressionArguments(arg);
                         }
                     });
                 };
@@ -865,8 +1082,11 @@ export class JavaTranspiler extends BaseTranspiler {
                     const leftSide = propAccess.expression;
                     if (leftSide.kind === ts.SyntaxKind.Identifier) {
                         if (this.ReassignedVars[this.getVarKey(leftSide)]) {
-                            res.push(leftSide.escapedText);
-                            const newNode = this.createNewNodeForFinalVar(leftSide.escapedText);
+                            const orig = leftSide.escapedText as string;
+                            const finalName = finalNameFor(leftSide, orig);
+                            res.push({ orig, final: finalName });
+                            const newNode = ts.factory.createIdentifier(finalName);
+                            (newNode as any).getFullText = () => finalName;
                             leftSide.escapedText = newNode.escapedText;
                             propAccess.expression = newNode;
                         }
@@ -881,8 +1101,11 @@ export class JavaTranspiler extends BaseTranspiler {
                     }
                     if (n.kind === ts.SyntaxKind.Identifier) {
                         if (this.ReassignedVars[this.getVarKey(n)]) {
-                            res.push(n.escapedText);
-                            const newNode = this.createNewNodeForFinalVar(n.escapedText);
+                            const orig = n.escapedText as string;
+                            const finalName = finalNameFor(n, orig);
+                            res.push({ orig, final: finalName });
+                            const newNode = ts.factory.createIdentifier(finalName);
+                            (newNode as any).getFullText = () => finalName;
                             return newNode;
                         }
                     }
@@ -904,29 +1127,22 @@ export class JavaTranspiler extends BaseTranspiler {
                 let left = prop.initializer.expression;
                 const right = prop.initializer.argumentExpression;
                 if (left.kind === ts.SyntaxKind.ElementAccessExpression) {
-                    // handle x[a][b][c]... recursively
-                    // let currentLeft = left;
                     while (left.kind === ts.SyntaxKind.ElementAccessExpression) {
-                        // const innerLeft = currentLeft.expression;
                         left = left.expression;
                     }
-
                 }
                 if (this.ReassignedVars[this.getVarKey(left)]) {
-                    const leftName = left.escapedText;
-                    const newLeftName = this.getFinalVarName(leftName);
-                    // const newLeftNode = ts.factory.createIdentifier(newLeftName);
-                    left.escapedText = newLeftName;
-                    // finalVars = finalVars + `final Object ${newLeftName} = ${leftName};\n`;
-                    res.push(leftName);
-
+                    const orig = left.escapedText as string;
+                    const finalName = finalNameFor(left, orig);
+                    left.escapedText = finalName;
+                    res.push({ orig, final: finalName });
                 }
                 if (right.kind === ts.SyntaxKind.Identifier) {
                     if (this.ReassignedVars[this.getVarKey(right)]) {
-                        const rightName = right.escapedText;
-                        const newRightName = this.getFinalVarName(rightName);
-                        right.escapedText = newRightName;
-                        res.push(rightName);
+                        const orig = right.escapedText as string;
+                        const finalName = finalNameFor(right, orig);
+                        right.escapedText = finalName;
+                        res.push({ orig, final: finalName });
                     }
                 }
             }
@@ -946,8 +1162,18 @@ export class JavaTranspiler extends BaseTranspiler {
                 res = res.concat(innerVars);
             }
         });
-        this.varListFromObjectLiterals[nodeId] =  [...new Set(res)];
-        return [...new Set(res)];
+
+        // dedup on (orig|final) pair
+        const seen = new Set<string>();
+        const dedup: Array<{ orig: string; final: string }> = [];
+        for (const p of res) {
+            const key = `${p.orig}|${p.final}`;
+            if (seen.has(key)) continue;
+            seen.add(key);
+            dedup.push(p);
+        }
+        this.varListFromObjectLiterals[nodeId] = dedup;
+        return dedup;
     }
 
     printVariableDeclarationList(node, identation) {
@@ -1123,71 +1349,18 @@ export class JavaTranspiler extends BaseTranspiler {
     }
 
     printFunctionBody(node, identation) {
-        this.emittedFinalVars = new Set();
         this.varListFromObjectLiterals = {};
-        this.pendingFinalVars = [];
-        // Collect method-body-level variable names (parameters + top-level declarations)
-        // so buildFinalVarDeclarations can decide whether to hoist or emit inline.
-        this.methodBodyVarNames = new Set();
+        this.analyzeFinalVars(node.body);
+        this.finalVarScopeStack = [new Set<string>()];
         const funcParams = node.parameters ?? [];
-        funcParams.forEach(p => {
-            const name = p.name?.escapedText;
-            if (name) this.methodBodyVarNames.add(name);
-        });
         const bodyStatements = node.body.statements;
-        for (const stmt of bodyStatements) {
-            if (ts.isVariableStatement(stmt)) {
-                for (const decl of stmt.declarationList.declarations) {
-                    const name = decl.name?.['escapedText'];
-                    if (name) this.methodBodyVarNames.add(name);
-                }
-            }
-        }
-        // Remove variables that are reassigned per-iteration in for-loops
-        // (loop counters must NOT be hoisted — their final copy must be per-iteration)
-        const collectLoopVars = (n: ts.Node) => {
-            if (ts.isIdentifier(n)) {
-                this.methodBodyVarNames.delete(n.escapedText as string);
-            }
-            ts.forEachChild(n, collectLoopVars);
-        };
-        for (const stmt of bodyStatements) {
-            if (ts.isForStatement(stmt)) {
-                if (stmt.initializer) {
-                    if (ts.isVariableDeclarationList(stmt.initializer)) {
-                        // for (let i = 0; ...) — extract declared names
-                        for (const decl of stmt.initializer.declarations) {
-                            const name = decl.name?.['escapedText'];
-                            if (name) this.methodBodyVarNames.delete(name as string);
-                        }
-                    } else {
-                        // for (i = 0; ...) — collect identifiers from assignment
-                        collectLoopVars(stmt.initializer);
-                    }
-                }
-                if (stmt.incrementor) {
-                    collectLoopVars(stmt.incrementor);
-                }
-            }
-        }
         const isAsync = this.isAsyncFunction(node);
         const initParams = [];
-        // Process each statement and hoist final var declarations to method body level
-        // when the source variable is at method-body scope. Loop/block-local vars stay inline.
         const processedParts = [];
         for (let i = 0; i < bodyStatements.length; i++) {
-            const pendingBefore = this.pendingFinalVars.length;
-            const printed = this.printNode(bodyStatements[i], identation + 1);
-            if (this.pendingFinalVars.length > pendingBefore) {
-                const newVars = this.pendingFinalVars.slice(pendingBefore);
-                const decls = newVars.map(v =>
-                    this.getIden(identation + 1) + `final Object ${v.final} = ${v.orig};`
-                ).join('\n');
-                processedParts.push(decls + '\n' + printed);
-            } else {
-                processedParts.push(printed);
-            }
+            processedParts.push(this.printNode(bodyStatements[i], identation + 1));
         }
+        this.finalVarScopeStack = [];
         let firstStatement = processedParts[0] || '';
         const remainingString = processedParts.slice(1).join("\n");
         let offSetIndex = 0;
@@ -1247,6 +1420,19 @@ export class JavaTranspiler extends BaseTranspiler {
         // }
 
         return super.printFunctionBody(node, identation);
+    }
+
+    printBlock(node, identation, chainBlock = false) {
+        // Track per-block scope for final var dedup: same final name must not be
+        // declared twice in a single block (Java would error), but may shadow
+        // across nested blocks. We push an empty scope on entry and pop on exit.
+        const managed = this.finalVarScopeStack.length > 0;
+        if (managed) this.finalVarScopeStack.push(new Set<string>());
+        try {
+            return super.printBlock(node, identation, chainBlock);
+        } finally {
+            if (managed) this.finalVarScopeStack.pop();
+        }
     }
 
     printInstanceOfExpression(node, identation) {
@@ -1322,8 +1508,10 @@ export class JavaTranspiler extends BaseTranspiler {
             let printedParam = this.printParameter(param);
             if (isAsyncMethod && isReassignedVar) {
                 const paramName = param.name.escapedText;
-                printedParam = printedParam.replace(paramName, `${paramName}2`);
-                // we have to rename the param, to then create the final wrapper nad finally inside method body bind the original name
+                const { localName, sigName } = this.getAsyncParamWrapperNames(paramName);
+                // Replace the printed Java name (post keyword-remap) with sigName so
+                // the original name is freed for the lambda body to bind.
+                printedParam = printedParam.replace(localName, sigName);
             }
             return printedParam;
         });
@@ -1355,7 +1543,8 @@ export class JavaTranspiler extends BaseTranspiler {
                     const isReassignedVar = this.ReassignedVars[this.getVarKey(param)];
                     if (isAsyncMethod && isReassignedVar) {
                         const paramName = param.name.escapedText;
-                        finalVarWrappers.push(this.getIden(identation + 1) + `final Object ${paramName}3 = ${paramName}2;`);
+                        const { sigName, snapName } = this.getAsyncParamWrapperNames(paramName);
+                        finalVarWrappers.push(this.getIden(identation + 1) + `final Object ${snapName} = ${sigName};`);
                     }
                 }
 
@@ -1376,7 +1565,8 @@ export class JavaTranspiler extends BaseTranspiler {
                     const isReassignedVar = this.ReassignedVars[this.getVarKey(param)];
                     if (isAsyncMethod && isReassignedVar) {
                         const paramName = param.name.escapedText;
-                        finalVarWrappers.push(this.getIden(identation + 1) + `Object ${paramName} = ${paramName}3;`);
+                        const { localName, snapName } = this.getAsyncParamWrapperNames(paramName);
+                        finalVarWrappers.push(this.getIden(identation + 1) + `Object ${localName} = ${snapName};`);
                     }
                 }
 

--- a/tests/javaTranspiler.test.ts
+++ b/tests/javaTranspiler.test.ts
@@ -1001,6 +1001,33 @@ describe('java transpiling tests', () => {
         expect(output).toMatch(/Helpers\.isEqual\(finalType, "swap"\).*\? false/);
     });
 
+    // --- Bug: PrefixUnaryExpression not handled for final var replacement ---
+
+    test('reassigned variable inside prefix unary expression in object literal gets finalXxx', () => {
+        const input =
+        "class T {\n" +
+        "    demo(x) {\n" +
+        "        let isSpot = true;\n" +
+        "        if (x !== undefined) {\n" +
+        "            isSpot = false;\n" +
+        "        }\n" +
+        "        return {\n" +
+        "            'spot': isSpot,\n" +
+        "            'type': isSpot ? 'spot' : 'swap',\n" +
+        "            'swap': !isSpot,\n" +
+        "            'contract': !isSpot,\n" +
+        "        };\n" +
+        "    }\n" +
+        "}"
+        const output = transpiler.transpileJava(input).content;
+        expect(output).toContain('final Object finalIsSpot = isSpot;');
+        // The !isSpot values must reference finalIsSpot, not raw isSpot
+        expect(output).toMatch(/put\(\s*"swap",\s*!Helpers\.isTrue\(finalIsSpot\)\s*\)/);
+        expect(output).toMatch(/put\(\s*"contract",\s*!Helpers\.isTrue\(finalIsSpot\)\s*\)/);
+        // No put value should reference raw isSpot
+        expect(output).not.toMatch(/put\(\s*"[^"]+",[^)]*\bisSpot\b/);
+    });
+
     test('nested ternary with reassigned variable', () => {
         const input =
         "class T {\n" +

--- a/tests/javaTranspiler.test.ts
+++ b/tests/javaTranspiler.test.ts
@@ -1194,6 +1194,66 @@ describe('java transpiling tests', () => {
         expect(output).not.toMatch(/put\(\s*"p",\s*x\.a\s*\)/);
     });
 
+    // Bug shape A (developer report): variable declared inside a nested block
+    // and conditionally reassigned must still get a final snapshot before its
+    // capture inside an object literal. Earlier versions only hoisted vars
+    // declared at the top of the function body.
+    test('object literal: var declared in nested block and reassigned conditionally gets final snapshot', () => {
+        const fresh = new Transpiler();
+        const input =
+        "class T {\n" +
+        "    async handleAccountIndex(params: any, methodName1: string): Promise<any> {\n" +
+        "        let accountIndex = undefined;\n" +
+        "        if (accountIndex === undefined) {\n" +
+        "            let walletAddress = this.walletAddress;\n" +
+        "            if (this.privateKey !== undefined) {\n" +
+        "                walletAddress = this.deriveAddress(this.privateKey);\n" +
+        "            }\n" +
+        "            const res = this.getByAddress({ 'l1_address': walletAddress });\n" +
+        "            return res;\n" +
+        "        }\n" +
+        "        return undefined;\n" +
+        "    }\n" +
+        "    walletAddress: any; privateKey: any;\n" +
+        "    deriveAddress(k: any) { return k; }\n" +
+        "    getByAddress(p: any) { return p; }\n" +
+        "}";
+        const output = fresh.transpileJava(input).content;
+        expect(output).toContain('final Object finalWalletAddress = walletAddress;');
+        expect(output).toMatch(/put\(\s*"l1_address",\s*finalWalletAddress\s*\)/);
+        expect(output).not.toMatch(/put\(\s*"l1_address",\s*walletAddress\s*\)/);
+    });
+
+    // Bug shape B (developer report): identifiers inside sub-expressions
+    // (BinaryExpression, ParenthesizedExpression, etc.) used as property values
+    // must also be remapped to the finalXxx name. Earlier versions only
+    // remapped top-level Identifier property values, leaving the binary
+    // expression's left side referencing the raw (non-final) name.
+    test('object literal: identifier nested in BinaryExpression property value is remapped to finalXxx', () => {
+        const fresh = new Transpiler();
+        const input =
+        "class T {\n" +
+        "    async parsePosition(marginModeId: number): Promise<any> {\n" +
+        "        let marginMode = undefined;\n" +
+        "        if (marginModeId !== undefined) {\n" +
+        "            marginMode = (marginModeId === 0) ? 'cross' : 'isolated';\n" +
+        "        }\n" +
+        "        return this.safePosition({\n" +
+        "            'isolated': (marginMode === 'isolated'),\n" +
+        "            'marginMode': marginMode,\n" +
+        "        });\n" +
+        "    }\n" +
+        "    safePosition(p: any) { return p; }\n" +
+        "}";
+        const output = fresh.transpileJava(input).content;
+        expect(output).toContain('final Object finalMarginMode = marginMode;');
+        // Plain-identifier property value: remapped.
+        expect(output).toMatch(/put\(\s*"marginMode",\s*finalMarginMode\s*\)/);
+        // Identifier nested inside a BinaryExpression must also be remapped.
+        expect(output).toMatch(/put\(\s*"isolated",[^)]*\bfinalMarginMode\b[^)]*\)/);
+        expect(output).not.toMatch(/Helpers\.isEqual\(\s*marginMode\b/);
+    });
+
     // --- Async method param wrapper: keyword-remapped names must round-trip ---
     // The async-method wrapper hoists each reassigned param into a final snapshot
     // outside the supplyAsync lambda and re-binds the original name inside it.

--- a/tests/javaTranspiler.test.ts
+++ b/tests/javaTranspiler.test.ts
@@ -1119,6 +1119,81 @@ describe('java transpiling tests', () => {
         expect(output).not.toMatch(/final Object finalParameters\s*=\s*params\s*;/);
     });
 
+    // --- Object-literal substitution coverage gaps ---
+    // The anonymous inner-class HashMap requires every captured variable to be
+    // effectively final. Each of these expression shapes used to leave the
+    // reassigned identifier raw inside the inner class, producing invalid Java.
+
+    test('object literal: postfix unary on reassigned counter gets finalized', () => {
+        const input =
+        "class T {\n" +
+        "    demo() {\n" +
+        "        let i = 0;\n" +
+        "        i = 1;\n" +
+        "        const a = { 'q': i++ };\n" +
+        "        return a;\n" +
+        "    }\n" +
+        "}";
+        const output = transpiler.transpileJava(input).content;
+        // The inner-class put must reference finalI, not raw i++ (which mutates a captured var).
+        expect(output).toContain('final Object finalI = i;');
+        // The inner class must not reference bare i in any capacity (would fail effectively-final).
+        expect(output).not.toMatch(/put\(\s*"q",\s*i\+\+\s*\)/);
+        expect(output).not.toMatch(/put\(\s*"q",[^)]*\bi\b(?!nal)/);
+    });
+
+    test('object literal: ElementAccessExpression inside a call argument substitutes the index', () => {
+        const input =
+        "class T {\n" +
+        "    demo(arr: any[]) {\n" +
+        "        let i = 0;\n" +
+        "        i = 1;\n" +
+        "        const a = { 'p': this.unwrap(arr[i]) };\n" +
+        "        return a;\n" +
+        "    }\n" +
+        "    unwrap(x: any) { return x; }\n" +
+        "}";
+        const output = transpiler.transpileJava(input).content;
+        expect(output).toContain('final Object finalI = i;');
+        // The index inside the inner-class put must read finalI, not raw i.
+        expect(output).toMatch(/put\(\s*"p",[^)]*\bfinalI\b/);
+        expect(output).not.toMatch(/put\(\s*"p",[^)]*GetValue\(\s*arr,\s*i\s*\)/);
+    });
+
+    test('object literal: nested object literal inside a ternary branch substitutes inner identifiers', () => {
+        const input =
+        "class T {\n" +
+        "    demo() {\n" +
+        "        let a = 1;\n" +
+        "        a = 2;\n" +
+        "        const o = { 'p': (a > 0) ? { 'q': a } : undefined };\n" +
+        "        return o;\n" +
+        "    }\n" +
+        "}";
+        const output = transpiler.transpileJava(input).content;
+        expect(output).toContain('final Object finalA = a;');
+        // The inner literal's `q` value must use finalA, not raw a.
+        expect(output).toMatch(/put\(\s*"q",\s*finalA\s*\)/);
+        expect(output).not.toMatch(/put\(\s*"q",\s*a\s*\)/);
+    });
+
+    test('object literal: PropertyAccessExpression on reassigned receiver substitutes the receiver', () => {
+        const input =
+        "class T {\n" +
+        "    demo() {\n" +
+        "        let x: any = {};\n" +
+        "        x = { a: 1 };\n" +
+        "        const o = { 'p': x.a };\n" +
+        "        return o;\n" +
+        "    }\n" +
+        "}";
+        const output = transpiler.transpileJava(input).content;
+        expect(output).toContain('final Object finalX = x;');
+        // The .a access inside the inner-class put must read finalX, not raw x.
+        expect(output).toMatch(/put\(\s*"p",[^)]*\bfinalX\b/);
+        expect(output).not.toMatch(/put\(\s*"p",\s*x\.a\s*\)/);
+    });
+
     // --- Async method param wrapper: keyword-remapped names must round-trip ---
     // The async-method wrapper hoists each reassigned param into a final snapshot
     // outside the supplyAsync lambda and re-binds the original name inside it.

--- a/tests/javaTranspiler.test.ts
+++ b/tests/javaTranspiler.test.ts
@@ -1198,7 +1198,10 @@ describe('java transpiling tests', () => {
     // and conditionally reassigned must still get a final snapshot before its
     // capture inside an object literal. Earlier versions only hoisted vars
     // declared at the top of the function body.
-    test('object literal: var declared in nested block and reassigned conditionally gets final snapshot', () => {
+    test('object literal: var declared in nested block and reassigned conditionally gets final snapshot (await-wrapped call initializer)', () => {
+        // The reported shape uses `const res = await this.x({...})` — the
+        // initializer's top kind is AwaitExpression, not CallExpression, so
+        // the old narrow branches in printVariableDeclarationList missed it.
         const fresh = new Transpiler();
         const input =
         "class T {\n" +
@@ -1209,19 +1212,73 @@ describe('java transpiling tests', () => {
         "            if (this.privateKey !== undefined) {\n" +
         "                walletAddress = this.deriveAddress(this.privateKey);\n" +
         "            }\n" +
-        "            const res = this.getByAddress({ 'l1_address': walletAddress });\n" +
+        "            const res = await this.getByAddress({ 'l1_address': walletAddress });\n" +
         "            return res;\n" +
         "        }\n" +
         "        return undefined;\n" +
         "    }\n" +
         "    walletAddress: any; privateKey: any;\n" +
         "    deriveAddress(k: any) { return k; }\n" +
-        "    getByAddress(p: any) { return p; }\n" +
+        "    async getByAddress(p: any) { return p; }\n" +
         "}";
         const output = fresh.transpileJava(input).content;
         expect(output).toContain('final Object finalWalletAddress = walletAddress;');
         expect(output).toMatch(/put\(\s*"l1_address",\s*finalWalletAddress\s*\)/);
         expect(output).not.toMatch(/put\(\s*"l1_address",\s*walletAddress\s*\)/);
+    });
+
+    // Extra initializer wrapping shapes where an ObjectLiteralExpression that
+    // captures a reassigned var is nested under a non-CallExpression wrapper.
+    // All of these previously skipped the hoist because the old branches only
+    // matched ObjectLiteralExpression or CallExpression directly.
+    test('object literal: initializer wrapped in ParenthesizedExpression still hoists final', () => {
+        const fresh = new Transpiler();
+        const input =
+        "class T {\n" +
+        "    demo() {\n" +
+        "        let x: any = 1;\n" +
+        "        x = 2;\n" +
+        "        const res = (this.f({ 'k': x }));\n" +
+        "        return res;\n" +
+        "    }\n" +
+        "    f(p: any) { return p; }\n" +
+        "}";
+        const output = fresh.transpileJava(input).content;
+        expect(output).toContain('final Object finalX = x;');
+        expect(output).toMatch(/put\(\s*"k",\s*finalX\s*\)/);
+    });
+
+    test('object literal: initializer wrapped in AwaitExpression+ObjectLiteral hoists final', () => {
+        const fresh = new Transpiler();
+        const input =
+        "class T {\n" +
+        "    async demo() {\n" +
+        "        let x: any = 1;\n" +
+        "        x = 2;\n" +
+        "        const res = await this.f({ 'k': x });\n" +
+        "        return res;\n" +
+        "    }\n" +
+        "    async f(p: any) { return p; }\n" +
+        "}";
+        const output = fresh.transpileJava(input).content;
+        expect(output).toContain('final Object finalX = x;');
+        expect(output).toMatch(/put\(\s*"k",\s*finalX\s*\)/);
+    });
+
+    test('object literal: initializer is ternary containing an ObjectLiteral branch', () => {
+        const fresh = new Transpiler();
+        const input =
+        "class T {\n" +
+        "    demo() {\n" +
+        "        let x: any = 1;\n" +
+        "        x = 2;\n" +
+        "        const res = (x > 0) ? { 'k': x } : undefined;\n" +
+        "        return res;\n" +
+        "    }\n" +
+        "}";
+        const output = fresh.transpileJava(input).content;
+        expect(output).toContain('final Object finalX = x;');
+        expect(output).toMatch(/put\(\s*"k",\s*finalX\s*\)/);
     });
 
     // Bug shape B (developer report): identifiers inside sub-expressions

--- a/tests/javaTranspiler.test.ts
+++ b/tests/javaTranspiler.test.ts
@@ -601,7 +601,10 @@ describe('java transpiling tests', () => {
 
     // --- Bug: finalXxx declared inside if-block but referenced outside it ---
 
-    test('finalXxx declaration is hoisted to method level when used in multiple scopes', () => {
+    test('finalXxx anchored at each usage site when used in multiple scopes', () => {
+        // Each usage gets its own anchored declaration. Declarations live in the
+        // narrowest scope that contains the usage so that nested-block
+        // reassignments cannot be hoisted past (correctness over minimization).
         const input =
         "class T {\n" +
         "    safeMarket(marketId) {\n" +
@@ -619,20 +622,16 @@ describe('java transpiling tests', () => {
         "    }\n" +
         "}"
         const output = transpiler.transpileJava(input).content;
-        // final declaration must appear exactly once
+        // Two usage sites in distinct scopes → two anchored declarations
         const declCount = (output.match(/final Object finalMarketId = marketId;/g) || []).length;
-        expect(declCount).toBe(1);
+        expect(declCount).toBe(2);
         // all put() calls should use finalMarketId
         const putMatches = output.match(/put\(\s*"symbol",\s*(\w+)\s*\)/g) || [];
         expect(putMatches.length).toBe(2);
         putMatches.forEach(m => expect(m).toContain('finalMarketId'));
-        // the declaration must be BEFORE the if block (at method level), not inside it
-        const declPos = output.indexOf('final Object finalMarketId = marketId;');
-        const ifPos = output.indexOf('if (');
-        expect(declPos).toBeLessThan(ifPos);
     });
 
-    test('finalXxx in if/else branches — declaration at method level', () => {
+    test('finalXxx in if/else branches — each branch gets its own anchored declaration', () => {
         const input =
         "class T {\n" +
         "    fetch(code) {\n" +
@@ -645,15 +644,12 @@ describe('java transpiling tests', () => {
         "    }\n" +
         "}"
         const output = transpiler.transpileJava(input).content;
+        // Each branch is a sibling scope → independent declarations
         const declCount = (output.match(/final Object finalCode = code;/g) || []).length;
-        expect(declCount).toBe(1);
-        // declaration must be before the if
-        const declPos = output.indexOf('final Object finalCode = code;');
-        const ifPos = output.indexOf('if (');
-        expect(declPos).toBeLessThan(ifPos);
+        expect(declCount).toBe(2);
     });
 
-    test('finalXxx in for-loop body then after loop — declaration at method level', () => {
+    test('finalXxx in for-loop body and after loop — anchored at each usage', () => {
         const input =
         "class T {\n" +
         "    process(data) {\n" +
@@ -666,11 +662,16 @@ describe('java transpiling tests', () => {
         "    }\n" +
         "}"
         const output = transpiler.transpileJava(input).content;
+        // One declaration inside the loop body, one before the return statement
         const declCount = (output.match(/final Object finalCode = code;/g) || []).length;
-        expect(declCount).toBe(1);
-        const declPos = output.indexOf('final Object finalCode = code;');
+        expect(declCount).toBe(2);
+        const decls = [...output.matchAll(/final Object finalCode = code;/g)].map(m => m.index!);
         const forPos = output.indexOf('for (');
-        expect(declPos).toBeLessThan(forPos);
+        const returnPos = output.lastIndexOf('return');
+        // first decl inside the loop, second before the return
+        expect(decls[0]).toBeGreaterThan(forPos);
+        expect(decls[1]).toBeLessThan(returnPos);
+        expect(decls[1]).toBeGreaterThan(forPos);
     });
 
     // --- Bug: over-aggressive hoisting of loop-local variables ---
@@ -697,7 +698,7 @@ describe('java transpiling tests', () => {
         expect(declPos).toBeGreaterThan(forPos);
     });
 
-    test('method-param variable IS hoisted but loop-local variable is NOT in same method', () => {
+    test('method-param variable gets an anchored declaration at each usage site', () => {
         const input =
         "class T {\n" +
         "    process(marketId, fees) {\n" +
@@ -712,14 +713,12 @@ describe('java transpiling tests', () => {
         "    }\n" +
         "}"
         const output = transpiler.transpileJava(input).content;
-        // marketId is a method param reassigned at method body level → hoisted
-        const marketDeclPos = output.indexOf('final Object finalMarketId = marketId;');
         const forPos = output.indexOf('for (');
-        expect(marketDeclPos).toBeGreaterThan(-1);
-        expect(marketDeclPos).toBeLessThan(forPos);
-        // code is loop-local → NOT hoisted, stays inside loop
+        // marketId used inside the loop and before the return — both anchored
+        const marketDecls = (output.match(/final Object finalMarketId = marketId;/g) || []).length;
+        expect(marketDecls).toBe(2);
+        // code is loop-local → stays inside loop
         const codeDeclPos = output.indexOf('final Object finalCode = code;');
-        expect(codeDeclPos).toBeGreaterThan(-1);
         expect(codeDeclPos).toBeGreaterThan(forPos);
     });
 
@@ -786,7 +785,7 @@ describe('java transpiling tests', () => {
         expect(finalDepositPos).toBeGreaterThan(forPos);
     });
 
-    test('method param hoisted, loop counter and loop-local stay inside loop', () => {
+    test('method-param, loop counter and loop-local all anchor at their own usage site', () => {
         const input =
         "class T {\n" +
         "    parseOrders(orders, marketId) {\n" +
@@ -806,10 +805,9 @@ describe('java transpiling tests', () => {
         "}"
         const output = transpiler.transpileJava(input).content;
         const forPos = output.indexOf('for (');
-        // marketId is method param → hoisted before loop
+        // marketId is only used inside the loop → one decl, inside the loop
         const finalMarketPos = output.indexOf('final Object finalMarketId');
-        expect(finalMarketPos).toBeGreaterThan(-1);
-        expect(finalMarketPos).toBeLessThan(forPos);
+        expect(finalMarketPos).toBeGreaterThan(forPos);
         // i and deposit are loop-scoped → inside loop
         const finalIPos = output.indexOf('final Object finalI');
         const finalDepositPos = output.indexOf('final Object finalDeposit');
@@ -863,7 +861,7 @@ describe('java transpiling tests', () => {
         expect(finalIPos).toBeGreaterThan(forPos);
     });
 
-    test('for-let loop counter used in element access ids[i] — finalI inside loop', () => {
+    test('for-let loop counter used in element access ids[i] — finalIds and finalI both inside loop', () => {
         const input =
         "class T {\n" +
         "    fetchMarkets(ids) {\n" +
@@ -877,12 +875,9 @@ describe('java transpiling tests', () => {
         "}"
         const output = transpiler.transpileJava(input).content;
         const forPos = output.indexOf('for (');
-        // finalIds should be hoisted (method param, reassigned before loop)
+        // Both ids and i are only used inside the loop → both anchored inside
         const finalIdsPos = output.indexOf('final Object finalIds');
-        expect(finalIdsPos).toBeGreaterThan(-1);
-        expect(finalIdsPos).toBeLessThan(forPos);
-        // finalI must be inside the loop (loop counter)
-        // Use regex to match finalI but not finalIds
+        expect(finalIdsPos).toBeGreaterThan(forPos);
         const afterFor = output.substring(forPos);
         expect(afterFor).toMatch(/final Object finalI\b/);
     });
@@ -1043,6 +1038,173 @@ describe('java transpiling tests', () => {
         expect(output).not.toMatch(/put\(\s*"v",.*\bx\b/);
     });
 
+    // --- Bug: hoisted final var captured pre-reassignment value (bybit.setMarginMode) ---
+
+    test('final var declaration lands AFTER nested-block reassignment, not before it', () => {
+        const input =
+        "class T {\n" +
+        "    fn(marginMode) {\n" +
+        "        const isUnifiedAccount = true;\n" +
+        "        if (isUnifiedAccount) {\n" +
+        "            if (marginMode === 'isolated') {\n" +
+        "                marginMode = 'ISOLATED_MARGIN';\n" +
+        "            } else if (marginMode === 'cross') {\n" +
+        "                marginMode = 'REGULAR_MARGIN';\n" +
+        "            }\n" +
+        "            const request = { 'setMarginMode': marginMode };\n" +
+        "            return request;\n" +
+        "        }\n" +
+        "    }\n" +
+        "}"
+        const output = transpiler.transpileJava(input).content;
+        const finalDeclIdx = output.indexOf('final Object finalMarginMode = marginMode;');
+        const firstReassignIdx = output.indexOf('marginMode = "ISOLATED_MARGIN"');
+        const secondReassignIdx = output.indexOf('marginMode = "REGULAR_MARGIN"');
+        expect(finalDeclIdx).toBeGreaterThan(-1);
+        expect(firstReassignIdx).toBeGreaterThan(-1);
+        expect(secondReassignIdx).toBeGreaterThan(-1);
+        expect(finalDeclIdx).toBeGreaterThan(firstReassignIdx);
+        expect(finalDeclIdx).toBeGreaterThan(secondReassignIdx);
+        expect(output).toMatch(/put\(\s*"setMarginMode",\s*finalMarginMode\s*\)/);
+    });
+
+    test('pathological: reassignment between two usages in same block uses distinct finals', () => {
+        const input =
+        "class T {\n" +
+        "    fn() {\n" +
+        "        let x = 'a';\n" +
+        "        x = 'b';\n" +
+        "        const a = { 'v': x };\n" +
+        "        x = 'c';\n" +
+        "        const b = { 'v': x };\n" +
+        "    }\n" +
+        "}"
+        const output = transpiler.transpileJava(input).content;
+        // Two distinct final snapshots (different suffixes) — one per version
+        const finalDecls = output.match(/final Object final\w+ = x;/g) || [];
+        expect(finalDecls.length).toBe(2);
+        const uniqueNames = new Set(finalDecls);
+        expect(uniqueNames.size).toBe(2);
+        // Each put must reference a final name, not raw x
+        const putMatches = output.match(/put\(\s*"v",\s*(\w+)\s*\)/g) || [];
+        expect(putMatches.length).toBe(2);
+        putMatches.forEach(m => expect(m).not.toMatch(/\bx\s*\)/));
+        // First decl must be between first reassignment and first usage; second decl between second reassignment and second usage
+        const firstReassignIdx = output.indexOf('x = "b"');
+        const secondReassignIdx = output.indexOf('x = "c"');
+        const firstPutIdx = output.indexOf('put( "v",');
+        const secondPutIdx = output.indexOf('put( "v",', firstPutIdx + 1);
+        const firstDeclIdx = output.indexOf('final Object final');
+        const secondDeclIdx = output.indexOf('final Object final', firstDeclIdx + 1);
+        expect(firstDeclIdx).toBeGreaterThan(firstReassignIdx);
+        expect(firstDeclIdx).toBeLessThan(firstPutIdx);
+        expect(secondDeclIdx).toBeGreaterThan(secondReassignIdx);
+        expect(secondDeclIdx).toBeLessThan(secondPutIdx);
+    });
+
+    test('reserved-keyword name (params/internal) — RHS uses the remapped Java identifier', () => {
+        // `params` is a reserved keyword in Java and is remapped to `parameters`.
+        // The final-var RHS must reference the remapped name, not the raw TS name.
+        const input =
+        "class T {\n" +
+        "    fetch(params) {\n" +
+        "        params = this.normalize(params);\n" +
+        "        return { 'p': params };\n" +
+        "    }\n" +
+        "}"
+        const output = transpiler.transpileJava(input).content;
+        // LHS is finalParameters, RHS must be parameters (not raw `params`)
+        expect(output).toContain('final Object finalParameters = parameters;');
+        // must NOT emit the raw TS name on the RHS
+        expect(output).not.toMatch(/final Object finalParameters\s*=\s*params\s*;/);
+    });
+
+    // --- Async method param wrapper: keyword-remapped names must round-trip ---
+    // The async-method wrapper hoists each reassigned param into a final snapshot
+    // outside the supplyAsync lambda and re-binds the original name inside it.
+    // For keyword-remapped params (e.g. `params` -> `parameters`) the wrapper
+    // names must be derived from the remapped Java identifier; otherwise the
+    // outside snapshot RHS references an undeclared variable.
+
+    test('async-wrapper: reassigned keyword-remapped param (params) — sig/snap/local round-trip on `parameters`', () => {
+        // Use a fresh transpiler to avoid cross-call ReassignedVars leakage
+        const fresh = new Transpiler();
+        const input =
+        "class T {\n" +
+        "  async handleAccountIndex(params: object, methodName1: string): Promise<any> {\n" +
+        "    let accountIndex = undefined;\n" +
+        "    [accountIndex, params] = this.handleOptionAndParams2(params, methodName1);\n" +
+        "    return accountIndex;\n" +
+        "  }\n" +
+        "  handleOptionAndParams2(p: object, m: string) { return [1, p]; }\n" +
+        "}";
+        const output = fresh.transpileJava(input).content;
+        // Signature: param is remapped + suffixed (Object parameters2)
+        expect(output).toMatch(/handleAccountIndex\s*\(\s*Object parameters2\b/);
+        // Outside snapshot: RHS = sig name (parameters2), LHS = parameters3
+        expect(output).toContain('final Object parameters3 = parameters2;');
+        // Inside lambda: local rebinds the post-keyword-remap name
+        expect(output).toContain('Object parameters = parameters3;');
+        // Must NOT emit the broken pre-fix output (`params2`/`params3` referenced anywhere)
+        expect(output).not.toMatch(/\bparams2\b/);
+        expect(output).not.toMatch(/\bparams3\b/);
+    });
+
+    test('async-wrapper: reassigned non-remapped param (body) — preserves existing body2/body3 shape', () => {
+        const fresh = new Transpiler();
+        const input =
+        "class T {\n" +
+        "  async f(body: string): Promise<any> {\n" +
+        "    body = 'x';\n" +
+        "    return body;\n" +
+        "  }\n" +
+        "}";
+        const output = fresh.transpileJava(input).content;
+        expect(output).toMatch(/f\s*\(\s*Object body2\b/);
+        expect(output).toContain('final Object body3 = body2;');
+        expect(output).toContain('Object body = body3;');
+    });
+
+    test('async-wrapper: other keyword-remapped params (internal, event) get correct wrappers', () => {
+        const fresh = new Transpiler();
+        // `internal` -> `intern`, `event` -> `eventVar`
+        const input =
+        "class T {\n" +
+        "  async f(internal: string, event: string): Promise<any> {\n" +
+        "    internal = 'x';\n" +
+        "    event = 'y';\n" +
+        "    return internal;\n" +
+        "  }\n" +
+        "}";
+        const output = fresh.transpileJava(input).content;
+        expect(output).toMatch(/f\s*\(\s*Object intern2,\s*Object eventVar2\b/);
+        expect(output).toContain('final Object intern3 = intern2;');
+        expect(output).toContain('final Object eventVar3 = eventVar2;');
+        expect(output).toContain('Object intern = intern3;');
+        expect(output).toContain('Object eventVar = eventVar3;');
+        // Pre-fix bug would emit `internal2`/`event2` on RHS — must not appear.
+        expect(output).not.toMatch(/\binternal2\b/);
+        expect(output).not.toMatch(/\bevent2\b/);
+    });
+
+    test('async-wrapper: mixed remapped + non-remapped reassigned params coexist', () => {
+        const fresh = new Transpiler();
+        const input =
+        "class T {\n" +
+        "  async f(params: object, body: string): Promise<any> {\n" +
+        "    params = {};\n" +
+        "    body = 'x';\n" +
+        "    return body;\n" +
+        "  }\n" +
+        "}";
+        const output = fresh.transpileJava(input).content;
+        expect(output).toMatch(/f\s*\(\s*Object parameters2,\s*Object body2\b/);
+        expect(output).toContain('final Object parameters3 = parameters2;');
+        expect(output).toContain('final Object body3 = body2;');
+        expect(output).toContain('Object parameters = parameters3;');
+        expect(output).toContain('Object body = body3;');
+    });
+
     // --- Integration: realistic exchange pattern combining all features ---
 
     test('async method with hoisted param, loop-local vars, ternaries, and two loops', () => {
@@ -1074,12 +1236,13 @@ describe('java transpiling tests', () => {
         "}"
         const output = transpiler.transpileJava(input).content;
         // every finalXxx reference must have a matching declaration
-        const allRefs = [...output.matchAll(/\\b(final[A-Z]\\w+)\\b/g)].map(m => m[1]);
-        const allDecls = new Set([...output.matchAll(/final Object (final\\w+)\\s*=/g)].map(m => m[1]));
+        const allRefs = [...output.matchAll(/\b(final[A-Z]\w+)\b/g)].map(m => m[1]);
+        const allDecls = new Set([...output.matchAll(/final Object (final\w+)\s*=/g)].map(m => m[1]));
         const undeclared = [...new Set(allRefs)].filter(r => !allDecls.has(r));
         expect(undeclared).toEqual([]);
-        // marketId hoisted (1 decl), code per-loop (2), i per-loop (2), type in first loop (1)
-        expect((output.match(/final Object finalMarketId/g) || []).length).toBe(1);
+        // marketId anchored at each usage (inside loop1, inside loop2, and before return) → 3
+        // code per-loop (2), i per-loop (2), type in first loop (1)
+        expect((output.match(/final Object finalMarketId/g) || []).length).toBe(3);
         expect((output.match(/final Object finalCode/g) || []).length).toBe(2);
         expect((output.match(/final Object finalI\b/g) || []).length).toBe(2);
         expect((output.match(/final Object finalType/g) || []).length).toBe(1);


### PR DESCRIPTION
Fixes several Java codegen bugs that broke the "effectively final" rule for object literals captured by anonymous inner classes (HashMap double-brace init).
Covers: `PrefixUnaryExpression` / `PostfixUnaryExpression` / `ElementAccessExpression` / `PropertyAccessExpression` inside property values; identifiers nested in `BinaryExpression` etc. via a unified `ts.forEachChild` walk; vars declared in nested blocks; initializers wrapped in `AwaitExpression` / `ParenthesizedExpression` / `NewExpression` / ternary via a new `collectCapturingObjectLiterals` helper; and async-method param wrappers for keyword-remapped names (`params` → `parameters`).
Adds 18 regression tests; full Java suite green (70/70).