### PR TITLE
fix(java): walk return-expression tree for HashMap captures

### DIFF
--- a/src/javaTranspiler.ts
+++ b/src/javaTranspiler.ts
@@ -848,11 +848,25 @@ export class JavaTranspiler extends BaseTranspiler {
         const reassignedSyms = new Set<string>();
         const discoverWalk = (node: any) => {
             if (!node) return;
-            if (node.kind === ts.SyntaxKind.BinaryExpression &&
-                node.left?.kind === ts.SyntaxKind.Identifier) {
-                // Mirror printCustomBinaryExpressionIfAny: any BinaryExpression
-                // with an Identifier left flags it, regardless of operator.
-                reassignedSyms.add(symbolIdOf(node.left));
+            if (node.kind === ts.SyntaxKind.BinaryExpression) {
+                if (node.left?.kind === ts.SyntaxKind.Identifier) {
+                    // Mirror printCustomBinaryExpressionIfAny: any BinaryExpression
+                    // with an Identifier left flags it, regardless of operator.
+                    reassignedSyms.add(symbolIdOf(node.left));
+                } else if (
+                    node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+                    node.left?.kind === ts.SyntaxKind.ArrayLiteralExpression
+                ) {
+                    // Tuple destructuring assignment: `[a, b] = expr`. The printer's
+                    // ArrayLiteralExpression branch in printCustomBinaryExpressionIfAny
+                    // flags each Identifier element in ReassignedVars, so mirror it
+                    // here for version-bump coverage.
+                    for (const elem of node.left.elements ?? []) {
+                        if (elem?.kind === ts.SyntaxKind.Identifier) {
+                            reassignedSyms.add(symbolIdOf(elem));
+                        }
+                    }
+                }
             }
             if ((node.kind === ts.SyntaxKind.PrefixUnaryExpression ||
                  node.kind === ts.SyntaxKind.PostfixUnaryExpression) &&

--- a/src/javaTranspiler.ts
+++ b/src/javaTranspiler.ts
@@ -844,6 +844,32 @@ export class JavaTranspiler extends BaseTranspiler {
         };
         discoverWalk(fnBody);
 
+        // Also include symbols whose <class>-<method>-<varName> key is already
+        // marked in ReassignedVars. That table accumulates across transpile
+        // calls and across earlier-printed methods in the same call, so a var
+        // declared as `const` in this function body may still be flagged from
+        // a prior context (cross-call state leak, or an alias seen earlier).
+        // The printer's traverseAndReplace already consults ReassignedVars as
+        // a fallback for substitution; if the analyzer doesn't know, it can't
+        // assign a version, the printer falls back to the un-suffixed base name
+        // for *all* uses, and sibling if/else branches share the same finalName
+        // — which is exactly the shape that breaks when the consumer's scope
+        // tracking suppresses the second declaration.
+        const includeFromReassignedVars = (node: any) => {
+            if (!node) return;
+            if (node.kind === ts.SyntaxKind.Identifier) {
+                const name = node.escapedText as string | undefined;
+                if (name && name !== 'undefined' && !name.startsWith?.('null')) {
+                    if (this.ReassignedVars[this.getVarKey(node)]) {
+                        reassignedSyms.add(symbolIdOf(node));
+                    }
+                }
+                return;
+            }
+            ts.forEachChild(node, includeFromReassignedVars);
+        };
+        includeFromReassignedVars(fnBody);
+
         if (reassignedSyms.size === 0) return;
 
         // Pass 2 — walk in source order, producing a stream of reassignment and usage

--- a/src/javaTranspiler.ts
+++ b/src/javaTranspiler.ts
@@ -1880,26 +1880,20 @@ export class JavaTranspiler extends BaseTranspiler {
         if (exp && exp.kind === ts.SyntaxKind.AsExpression && (exp.expression.kind === ts.SyntaxKind.ObjectLiteralExpression || ts.SyntaxKind.CallExpression)) {
             exp = exp.expression; // go over something like return {} as SomeType
         }
+        // Use collectCapturingObjectLiterals to walk through every wrapper
+        // (AwaitExpression, ParenthesizedExpression, CallExpression args, ArrayLiteral
+        // elements, ConditionalExpression branches, NewExpression args, etc.) and
+        // pick up every HashMap literal whose anonymous-inner-class body would
+        // need effectively-final captures. The previous narrow switch missed
+        // `return await this.watch(..., { literal capturing reassigned var }, ...)`
+        // entirely — the literal ended up referencing the raw (reassigned)
+        // identifier with no snapshot, which javac rejects.
         const allVarNames = [];
-        if (exp && exp?.kind === ts.SyntaxKind.ObjectLiteralExpression) {
-            const varsList = this.getVarListFromObjectLiteralAndUpdateInPlace(exp);
-            allVarNames.push(...varsList);
-        } else if (exp && exp?.kind === ts.SyntaxKind.CallExpression) {
-            const objectsFromCall = this.getObjectLiteralFromCallExpressionArguments(exp);
-            for (const objLiteral of objectsFromCall) {
+        if (exp) {
+            const objLiterals = this.collectCapturingObjectLiterals(exp);
+            for (const objLiteral of objLiterals) {
                 const varsList = this.getVarListFromObjectLiteralAndUpdateInPlace(objLiteral);
                 allVarNames.push(...varsList);
-            }
-        } else if (exp && exp?.kind === ts.SyntaxKind.ArrayLiteralExpression) {
-            const elements = exp?.elements ?? [];
-            for (const element of elements) {
-                if (element.kind === ts.SyntaxKind.CallExpression) {
-                    const objectsFromCall = this.getObjectLiteralFromCallExpressionArguments(element);
-                    for (const objLiteral of objectsFromCall) {
-                        const varsList = this.getVarListFromObjectLiteralAndUpdateInPlace(objLiteral);
-                        allVarNames.push(...varsList);
-                    }
-                }
             }
         }
         let finalVars = allVarNames.length > 0 ? this.buildFinalVarDeclarations(allVarNames, identation) : '';

--- a/src/javaTranspiler.ts
+++ b/src/javaTranspiler.ts
@@ -955,20 +955,21 @@ export class JavaTranspiler extends BaseTranspiler {
                 return;
             }
 
-            // If/else branches are mutually exclusive, but the analyzer walks
-            // them sequentially — so without intervention, a symbol with the
-            // same reassign-counter in both branches gets the same version name
-            // (e.g. `finalRequestOp`). When both branches emit a HashMap literal
-            // capturing that symbol, they'd share the snapshot name; if scope
-            // tracking ever loses track of the if-branch's pop, the else branch's
-            // declaration gets suppressed by the ancestor-scope check.
+            // An if-block introduces a sibling scope for declarations inside it.
+            // Without intervention, the analyzer assigns the same per-symbol
+            // version to uses inside the then-block and uses after the if (or
+            // inside the else-block) — same name, same emit target. Java permits
+            // sibling-scope reuse of a name when the inner block has popped,
+            // but ancestor-scope dedup in buildFinalVarDeclarations + any scope
+            // tracking leak in the consumer environment can suppress the outer
+            // declaration, leaving an undeclared reference.
             //
-            // Insert a phantom reassign event at the boundary between then and
-            // else for every symbol used inside the then-block. This bumps the
-            // counter so else-block uses get a distinct version (`finalRequestOp_2`),
-            // making the snapshots unique per-branch even if the analyzer's
-            // expression-kind coverage misses some shape inside the literal.
-            if (node.kind === ts.SyntaxKind.IfStatement && node.elseStatement) {
+            // Insert phantom reassign events at block boundaries so:
+            //   - then-block uses get version N
+            //   - else-block uses (if present) get version N+1
+            //   - post-if uses get the next version after both branches
+            // Names are distinct per region; ancestor-scope dedup becomes a no-op.
+            if (node.kind === ts.SyntaxKind.IfStatement) {
                 walk(node.expression);
                 const eventsBeforeThen = events.length;
                 walk(node.thenStatement);
@@ -977,10 +978,37 @@ export class JavaTranspiler extends BaseTranspiler {
                     const e = events[i];
                     if (e.kind === 'use') usedInThen.add(e.sym);
                 }
+                // Bump version for every symbol used inside then — separates
+                // then-block name from any subsequent (else-block or post-if) use.
                 for (const sym of usedInThen) {
                     events.push({ kind: 'reassign', sym });
                 }
-                walk(node.elseStatement);
+                const usedInThenOrElse = new Set<string>(usedInThen);
+                if (node.elseStatement) {
+                    const eventsBeforeElse = events.length;
+                    walk(node.elseStatement);
+                    for (let i = eventsBeforeElse; i < events.length; i++) {
+                        const e = events[i];
+                        if (e.kind === 'use') usedInThenOrElse.add(e.sym);
+                    }
+                    // Bump again so any post-if use gets a distinct version
+                    // from BOTH branches.
+                    for (const sym of usedInThenOrElse) {
+                        if (!usedInThen.has(sym)) {
+                            // Already bumped once for then-only symbols; bump
+                            // the remaining (else-only) ones here.
+                            events.push({ kind: 'reassign', sym });
+                        }
+                    }
+                    // For symbols used in BOTH branches, we already bumped once
+                    // between then and else; do an additional bump here so post-if
+                    // gets a unique version beyond the else-branch version.
+                    for (const sym of usedInThen) {
+                        if (usedInThenOrElse.has(sym)) {
+                            events.push({ kind: 'reassign', sym });
+                        }
+                    }
+                }
                 return;
             }
 

--- a/src/javaTranspiler.ts
+++ b/src/javaTranspiler.ts
@@ -907,7 +907,14 @@ export class JavaTranspiler extends BaseTranspiler {
                 });
                 return;
             }
-            // Other shapes (property access, literals, etc.) — ignore.
+            // Fallback for any other expression kind (ArrayLiteralExpression,
+            // SpreadElement, TemplateExpression, AsExpression, NonNullExpression,
+            // PropertyAccessExpression, TypeAssertion, etc.) — descend uniformly
+            // so identifiers nested inside `[rawHash]`, `{...x}`, `` `${x}` ``, and
+            // so on are still tagged. ObjectLiteralExpression is handled above so
+            // it doesn't fall through to the generic descent (which would re-walk
+            // the same prop initializers and double-count).
+            ts.forEachChild(n, visitExprInObjLit);
         };
 
         const walk = (node: any) => {
@@ -945,6 +952,35 @@ export class JavaTranspiler extends BaseTranspiler {
                         walk(prop.initializer);
                     }
                 });
+                return;
+            }
+
+            // If/else branches are mutually exclusive, but the analyzer walks
+            // them sequentially — so without intervention, a symbol with the
+            // same reassign-counter in both branches gets the same version name
+            // (e.g. `finalRequestOp`). When both branches emit a HashMap literal
+            // capturing that symbol, they'd share the snapshot name; if scope
+            // tracking ever loses track of the if-branch's pop, the else branch's
+            // declaration gets suppressed by the ancestor-scope check.
+            //
+            // Insert a phantom reassign event at the boundary between then and
+            // else for every symbol used inside the then-block. This bumps the
+            // counter so else-block uses get a distinct version (`finalRequestOp_2`),
+            // making the snapshots unique per-branch even if the analyzer's
+            // expression-kind coverage misses some shape inside the literal.
+            if (node.kind === ts.SyntaxKind.IfStatement && node.elseStatement) {
+                walk(node.expression);
+                const eventsBeforeThen = events.length;
+                walk(node.thenStatement);
+                const usedInThen = new Set<string>();
+                for (let i = eventsBeforeThen; i < events.length; i++) {
+                    const e = events[i];
+                    if (e.kind === 'use') usedInThen.add(e.sym);
+                }
+                for (const sym of usedInThen) {
+                    events.push({ kind: 'reassign', sym });
+                }
+                walk(node.elseStatement);
                 return;
             }
 

--- a/src/javaTranspiler.ts
+++ b/src/javaTranspiler.ts
@@ -1041,6 +1041,16 @@ export class JavaTranspiler extends BaseTranspiler {
                 return;
             }
 
+            // try / catch / finally: catch is a sibling scope to try; finally
+            // executes after both. Treat each block the same way as if/else
+            // branches so captures across them get distinct snapshot names.
+            if (node.kind === ts.SyntaxKind.TryStatement) {
+                walkBlockAndBump(node.tryBlock);
+                walkBlockAndBump(node.catchClause?.block);
+                walkBlockAndBump(node.finallyBlock);
+                return;
+            }
+
             ts.forEachChild(node, walk);
         };
 

--- a/src/javaTranspiler.ts
+++ b/src/javaTranspiler.ts
@@ -846,7 +846,7 @@ export class JavaTranspiler extends BaseTranspiler {
         // version-bump machinery (a5c2036 / ac618b0 / 48a1786) can assign
         // distinct names to sibling and post-block uses.
         const reassignedSyms = new Set<string>();
-        const discoverWalk = (node: any) => {
+        const discoverPotentialReassignments = (node: any) => {
             if (!node) return;
             if (node.kind === ts.SyntaxKind.BinaryExpression) {
                 if (node.left?.kind === ts.SyntaxKind.Identifier) {
@@ -874,23 +874,13 @@ export class JavaTranspiler extends BaseTranspiler {
                 node.operand?.kind === ts.SyntaxKind.Identifier) {
                 reassignedSyms.add(symbolIdOf(node.operand));
             }
-            ts.forEachChild(node, discoverWalk);
-        };
-        discoverWalk(fnBody);
-
-        // Also include symbols whose <class>-<method>-<varName> key is already
-        // marked in ReassignedVars. That table accumulates across transpile
-        // calls and across earlier-printed methods in the same call, so a var
-        // declared as `const` in this function body may still be flagged from
-        // a prior context (cross-call state leak, or an alias seen earlier).
-        // The printer's traverseAndReplace already consults ReassignedVars as
-        // a fallback for substitution; if the analyzer doesn't know, it can't
-        // assign a version, the printer falls back to the un-suffixed base name
-        // for *all* uses, and sibling if/else branches share the same finalName
-        // — which is exactly the shape that breaks when the consumer's scope
-        // tracking suppresses the second declaration.
-        const includeFromReassignedVars = (node: any) => {
-            if (!node) return;
+            // Cross-call / cross-method state leak: ReassignedVars accumulates
+            // across transpile calls and earlier-printed methods in the same
+            // class+method context, so a var declared `const` in this function
+            // body may still be flagged from a prior context. The printer's
+            // substitution path consults ReassignedVars as a fallback; if the
+            // analyzer disagrees, version-bump can't apply and sibling if/else
+            // branches end up with the same base name.
             if (node.kind === ts.SyntaxKind.Identifier) {
                 const name = node.escapedText as string | undefined;
                 if (name && name !== 'undefined' && !name.startsWith?.('null')) {
@@ -900,9 +890,9 @@ export class JavaTranspiler extends BaseTranspiler {
                 }
                 return;
             }
-            ts.forEachChild(node, includeFromReassignedVars);
+            ts.forEachChild(node, discoverPotentialReassignments);
         };
-        includeFromReassignedVars(fnBody);
+        discoverPotentialReassignments(fnBody);
 
         if (reassignedSyms.size === 0) return;
 
@@ -1015,60 +1005,39 @@ export class JavaTranspiler extends BaseTranspiler {
                 return;
             }
 
-            // An if-block introduces a sibling scope for declarations inside it.
-            // Without intervention, the analyzer assigns the same per-symbol
-            // version to uses inside the then-block and uses after the if (or
-            // inside the else-block) — same name, same emit target. Java permits
-            // sibling-scope reuse of a name when the inner block has popped,
-            // but ancestor-scope dedup in buildFinalVarDeclarations + any scope
-            // tracking leak in the consumer environment can suppress the outer
-            // declaration, leaving an undeclared reference.
+            // If/else branches introduce sibling scopes for declarations inside
+            // them. Without intervention, the analyzer assigns the same per-symbol
+            // version to uses across siblings and to uses after the branch.
+            // Java permits sibling-scope name reuse when the inner block has
+            // popped, but ancestor-scope dedup in buildFinalVarDeclarations +
+            // any scope tracking leak in the consumer environment can suppress
+            // the outer declaration, leaving an undeclared reference.
             //
-            // Insert phantom reassign events at block boundaries so:
-            //   - then-block uses get version N
-            //   - else-block uses (if present) get version N+1
-            //   - post-if uses get the next version after both branches
-            // Names are distinct per region; ancestor-scope dedup becomes a no-op.
-            if (node.kind === ts.SyntaxKind.IfStatement) {
-                walk(node.expression);
-                const eventsBeforeThen = events.length;
-                walk(node.thenStatement);
-                const usedInThen = new Set<string>();
-                for (let i = eventsBeforeThen; i < events.length; i++) {
+            // The helper below records 'use' events inside a sub-block and emits
+            // a phantom reassign on exit for every symbol used inside, so each
+            // region gets a distinct per-symbol version → distinct finalXxx name.
+            const walkBlockAndBump = (subNode: ts.Node | undefined): Set<string> => {
+                const usedInBlock = new Set<string>();
+                if (!subNode) return usedInBlock;
+                const eventsBefore = events.length;
+                walk(subNode);
+                for (let i = eventsBefore; i < events.length; i++) {
                     const e = events[i];
-                    if (e.kind === 'use') usedInThen.add(e.sym);
+                    if (e.kind === 'use') usedInBlock.add(e.sym);
                 }
-                // Bump version for every symbol used inside then — separates
-                // then-block name from any subsequent (else-block or post-if) use.
-                for (const sym of usedInThen) {
+                for (const sym of usedInBlock) {
                     events.push({ kind: 'reassign', sym });
                 }
-                const usedInThenOrElse = new Set<string>(usedInThen);
-                if (node.elseStatement) {
-                    const eventsBeforeElse = events.length;
-                    walk(node.elseStatement);
-                    for (let i = eventsBeforeElse; i < events.length; i++) {
-                        const e = events[i];
-                        if (e.kind === 'use') usedInThenOrElse.add(e.sym);
-                    }
-                    // Bump again so any post-if use gets a distinct version
-                    // from BOTH branches.
-                    for (const sym of usedInThenOrElse) {
-                        if (!usedInThen.has(sym)) {
-                            // Already bumped once for then-only symbols; bump
-                            // the remaining (else-only) ones here.
-                            events.push({ kind: 'reassign', sym });
-                        }
-                    }
-                    // For symbols used in BOTH branches, we already bumped once
-                    // between then and else; do an additional bump here so post-if
-                    // gets a unique version beyond the else-branch version.
-                    for (const sym of usedInThen) {
-                        if (usedInThenOrElse.has(sym)) {
-                            events.push({ kind: 'reassign', sym });
-                        }
-                    }
-                }
+                return usedInBlock;
+            };
+
+            if (node.kind === ts.SyntaxKind.IfStatement) {
+                walk(node.expression);
+                walkBlockAndBump(node.thenStatement);
+                walkBlockAndBump(node.elseStatement);
+                // After walking either branch we've already bumped for every
+                // symbol used inside it, so post-if uses naturally land on a
+                // version higher than either branch's uses.
                 return;
             }
 

--- a/src/javaTranspiler.ts
+++ b/src/javaTranspiler.ts
@@ -825,13 +825,33 @@ export class JavaTranspiler extends BaseTranspiler {
             return `n:${n.escapedText}`;
         };
 
-        // Pass 1 — discover which symbols are reassigned anywhere in this function body.
+        // Pass 1 — discover which symbols the printer will treat as reassigned.
+        //
+        // The printer's `printCustomBinaryExpressionIfAny` sets
+        // `ReassignedVars[varKey] = true` for the LEFT identifier of *every*
+        // BinaryExpression — not just assignment operators. So `timestamp + '#'`
+        // or `x === 5` will both flag `timestamp`/`x` later during emit, even
+        // though they're plain reads syntactically. The printer's substitution
+        // path then uses ReassignedVars as a fallback trigger for the finalXxx
+        // rewrite, so a literal capturing such an identifier ends up referring
+        // to `finalTimestamp` even when the analyzer thinks the symbol isn't
+        // reassigned.
+        //
+        // If the analyzer disagrees with the printer here, the printer's
+        // fallback substitution uses the un-suffixed base name for *every* use
+        // (including in sibling if/else branches), and any environment with
+        // ancestor-scope dedup leak will suppress one of the two declarations.
+        //
+        // Mirror the printer's over-broad heuristic in the analyzer so the
+        // version-bump machinery (a5c2036 / ac618b0 / 48a1786) can assign
+        // distinct names to sibling and post-block uses.
         const reassignedSyms = new Set<string>();
         const discoverWalk = (node: any) => {
             if (!node) return;
             if (node.kind === ts.SyntaxKind.BinaryExpression &&
-                this.isAssignmentOperator(node.operatorToken.kind) &&
                 node.left?.kind === ts.SyntaxKind.Identifier) {
+                // Mirror printCustomBinaryExpressionIfAny: any BinaryExpression
+                // with an Identifier left flags it, regardless of operator.
                 reassignedSyms.add(symbolIdOf(node.left));
             }
             if ((node.kind === ts.SyntaxKind.PrefixUnaryExpression ||

--- a/tests/javaTranspiler.test.ts
+++ b/tests/javaTranspiler.test.ts
@@ -1525,6 +1525,93 @@ describe('java transpiling tests', () => {
 
     // --- Integration: realistic exchange pattern combining all features ---
 
+    // Regression: CCXT-style WS subscribe — `return await this.watch(..., { ...rawHash... }, rawHash)`.
+    // The HashMap argument capture needs an effectively-final snapshot of `rawHash`,
+    // even though the return expression is wrapped in `AwaitExpression`. Pre-fix,
+    // printReturnStatement only matched ObjectLiteralExpression/CallExpression/
+    // ArrayLiteralExpression at the top level, so AwaitExpression-wrapped returns
+    // produced raw `rawHash` inside the anon-inner-class — javac rejected it.
+    test('return await call(...{literal-capturing-reassigned}, ...): per-branch final snapshot is emitted', () => {
+        const fresh = new Transpiler();
+        const input =
+        "class T {\n" +
+        "    async subscribe(symbol: string, type: string): Promise<any> {\n" +
+        "        let rawHash = undefined;\n" +
+        "        const messageHash = 'ticker:' + symbol;\n" +
+        "        if (type === 'spot') {\n" +
+        "            rawHash = 'spot/ticker:' + symbol;\n" +
+        "            return await this.watch('url', messageHash, { 'op': 'subscribe', 'args': [ rawHash ] }, rawHash);\n" +
+        "        } else {\n" +
+        "            rawHash = 'futures/ticker:' + symbol;\n" +
+        "            return await this.watch('url', messageHash, { 'op': 'subscribe', 'args': [ rawHash ] }, rawHash);\n" +
+        "        }\n" +
+        "    }\n" +
+        "    async watch(url: string, hash: string, request: any, sub: string): Promise<any> { return [url, hash, request, sub]; }\n" +
+        "}";
+        const output = fresh.transpileJava(input).content;
+        // The HashMap argument must read finalRawHash, not raw rawHash.
+        expect(output).toMatch(/Arrays\.asList\(\s*finalRawHash\s*\)/);
+        expect(output).not.toMatch(/Arrays\.asList\(\s*rawHash\s*\)/);
+        // Each branch declares its own snapshot, after the reassignment.
+        expect((output.match(/final Object finalRawHash = rawHash;/g) || []).length).toBe(2);
+        // Snapshot must be in the same branch as the reassignment.
+        const branchPattern =
+            /rawHash = Helpers\.add\([^;]*\);\s*final Object finalRawHash = rawHash;\s*return\b/g;
+        expect((output.match(branchPattern) || []).length).toBe(2);
+        // No method-scope snapshot before the if/else (which would capture null).
+        expect(output).not.toMatch(/final Object finalRawHash = rawHash;\s*if\s*\(/);
+        // every finalXxx reference must have a matching declaration
+        const allRefs = [...output.matchAll(/\b(final[A-Z]\w+)\b/g)].map(m => m[1]);
+        const allDecls = new Set([...output.matchAll(/final Object (final\w+)\s*=/g)].map(m => m[1]));
+        const undeclared = [...new Set(allRefs)].filter(r => !allDecls.has(r));
+        expect(undeclared).toEqual([]);
+    });
+
+    // Regression: bitmart-style subscribe helper. `rawHash` is declared with
+    // `undefined`, then reassigned inside each if/else branch and immediately
+    // used inside a HashMap literal in that same branch. The final-var snapshot
+    // must be placed *inside* each branch, *after* the reassignment — never at
+    // method scope before the if/else (which would capture null).
+    test('object literal: per-branch reassignment captures branch-local snapshot, not method-scope null', () => {
+        const fresh = new Transpiler();
+        const input =
+        "class T {\n" +
+        "    async subscribe(symbol: string, op: string, kind: string): Promise<any> {\n" +
+        "        let rawHash = undefined;\n" +
+        "        let request = {};\n" +
+        "        if (kind === 'spot') {\n" +
+        "            rawHash = 'spot/ticker:' + symbol;\n" +
+        "            request = { 'op': op, 'args': [ rawHash ] };\n" +
+        "        } else {\n" +
+        "            rawHash = 'futures/ticker:' + symbol;\n" +
+        "            request = { 'op': op, 'args': [ rawHash ] };\n" +
+        "        }\n" +
+        "        return JSON.stringify(request);\n" +
+        "    }\n" +
+        "}";
+        const output = fresh.transpileJava(input).content;
+        // The literal must read from finalRawHash, not raw rawHash.
+        expect(output).toMatch(/Arrays\.asList\(\s*finalRawHash\s*\)/);
+        expect(output).not.toMatch(/Arrays\.asList\(\s*rawHash\s*\)/);
+        // The snapshot must be inside each branch (after the reassignment),
+        // not at method scope before the if. There are two branches → two snapshots.
+        expect((output.match(/final Object finalRawHash = rawHash;/g) || []).length).toBe(2);
+        // The snapshot must come AFTER the corresponding reassignment in each branch.
+        // We assert structurally: each snapshot is preceded by a `rawHash = Helpers.add(...)`
+        // line, with no intervening `if (` on the same path.
+        const branchPattern =
+            /rawHash = Helpers\.add\([^;]*\);\s*final Object finalRawHash = rawHash;\s*request = new java\.util\.HashMap/g;
+        expect((output.match(branchPattern) || []).length).toBe(2);
+        // Must NOT emit a method-scope snapshot before the if/else
+        // (which the pre-fix output did, capturing the null seed value).
+        expect(output).not.toMatch(/final Object finalRawHash = rawHash;\s*if\s*\(/);
+        // every finalXxx reference must have a matching declaration
+        const allRefs = [...output.matchAll(/\b(final[A-Z]\w+)\b/g)].map(m => m[1]);
+        const allDecls = new Set([...output.matchAll(/final Object (final\w+)\s*=/g)].map(m => m[1]));
+        const undeclared = [...new Set(allRefs)].filter(r => !allDecls.has(r));
+        expect(undeclared).toEqual([]);
+    });
+
     test('async method with hoisted param, loop-local vars, ternaries, and two loops', () => {
         const input =
         "class Exchange {\n" +

--- a/tests/javaTranspiler.test.ts
+++ b/tests/javaTranspiler.test.ts
@@ -1584,6 +1584,44 @@ describe('java transpiling tests', () => {
         expect(undeclared).toEqual([]);
     });
 
+    // Regression (real CCXT bingx watchOrderBook shape): `params` is reassigned
+    // via tuple-destructure (`[marketType, params] = this.handle(...)`). The
+    // printer's ArrayLiteralExpression branch in printCustomBinaryExpressionIfAny
+    // flags each element in ReassignedVars at emit time. Pass 1 needs to mirror
+    // this so the version-bump fires; otherwise sibling if/else captures share
+    // `finalParameters` and the else-branch declaration can be suppressed.
+    test('object literal: tuple-destructure target captured in if/else literals — distinct per-branch snapshots', () => {
+        const fresh = new Transpiler();
+        const input =
+        "class T {\n" +
+        "    async watchOrderBook(symbol, limit = undefined, params = {}) {\n" +
+        "        let marketType = undefined;\n" +
+        "        [ marketType, params ] = this.handleMarketTypeAndParams('watchOrderBook', undefined, params);\n" +
+        "        let subscriptionArgs = {};\n" +
+        "        if (this.someFlag(symbol)) {\n" +
+        "            subscriptionArgs = { 'params': params };\n" +
+        "        } else {\n" +
+        "            subscriptionArgs = { 'params': params };\n" +
+        "        }\n" +
+        "        return subscriptionArgs;\n" +
+        "    }\n" +
+        "    handleMarketTypeAndParams(method, market, params) { return [undefined, params]; }\n" +
+        "    someFlag(s) { return true; }\n" +
+        "}";
+        const output = fresh.transpileJava(input).content;
+        // Both branches declare their own snapshot with distinct names.
+        expect(output).toMatch(/final Object finalParameters = parameters;/);
+        expect(output).toMatch(/final Object finalParameters_2 = parameters;/);
+        // Each literal references its branch's own snapshot.
+        expect(output).toMatch(/put\(\s*"params",\s*finalParameters\s*\)/);
+        expect(output).toMatch(/put\(\s*"params",\s*finalParameters_2\s*\)/);
+        // No undeclared finalXxx anywhere.
+        const allRefs = [...output.matchAll(/\b(final[A-Z]\w+)\b/g)].map(m => m[1]);
+        const allDecls = new Set([...output.matchAll(/final Object (final\w+)\s*=/g)].map(m => m[1]));
+        const undeclared = [...new Set(allRefs)].filter(r => !allDecls.has(r));
+        expect(undeclared).toEqual([]);
+    });
+
     // Regression (real CCXT bitmart authenticate shape): the var `timestamp` is
     // declared `const` (never reassigned in source) but later used as the left
     // side of a BinaryExpression (`timestamp + '#' + memo`). The printer flags

--- a/tests/javaTranspiler.test.ts
+++ b/tests/javaTranspiler.test.ts
@@ -1622,6 +1622,66 @@ describe('java transpiling tests', () => {
         expect(undeclared).toEqual([]);
     });
 
+    // Coverage gap: deeply nested if/else where the inner branches and the
+    // outer post-if all capture the same reassigned symbol. The version bump
+    // must propagate up through nested IfStatement walks so each region gets
+    // a distinct snapshot name.
+    test('object literal: deeply nested if/else — each region gets a distinct snapshot', () => {
+        const fresh = new Transpiler();
+        const input =
+        "class T {\n" +
+        "    async f(type, sub) {\n" +
+        "        let x = 'init';\n" +
+        "        x = x + '!';\n" +
+        "        if (type === 'a') {\n" +
+        "            if (sub === 'x') {\n" +
+        "                return { 'v': x };\n" +
+        "            } else {\n" +
+        "                return { 'v': x };\n" +
+        "            }\n" +
+        "        }\n" +
+        "        return { 'v': x };\n" +
+        "    }\n" +
+        "}";
+        const output = fresh.transpileJava(input).content;
+        // Three distinct regions → three distinct snapshot names.
+        const decls = [...output.matchAll(/final Object (finalX\w*) = x;/g)].map(m => m[1]);
+        const unique = new Set(decls);
+        expect(unique.size).toBe(3);
+        expect(decls.length).toBe(3);
+        // Every finalXxx reference must resolve to a declaration.
+        const allRefs = [...output.matchAll(/\b(final[A-Z]\w+)\b/g)].map(m => m[1]);
+        const allDecls = new Set([...output.matchAll(/final Object (final\w+)\s*=/g)].map(m => m[1]));
+        const undeclared = [...new Set(allRefs)].filter(r => !allDecls.has(r));
+        expect(undeclared).toEqual([]);
+    });
+
+    // Negative regression: a var that is truly never reassigned and only read
+    // outside any BinaryExpression context must NOT get a snapshot in the
+    // captured literal. Catches accidental over-eager versioning from the
+    // pass-1 broadening (mirror of printCustomBinaryExpressionIfAny).
+    test('object literal: truly read-only var captured in if/else — NO snapshot emitted', () => {
+        const fresh = new Transpiler();
+        const input =
+        "class T {\n" +
+        "    async f(type) {\n" +
+        "        const x = 'const';\n" +
+        "        let r = undefined;\n" +
+        "        if (type === 'a') {\n" +
+        "            r = { 'v': x };\n" +
+        "        } else {\n" +
+        "            r = { 'v': x };\n" +
+        "        }\n" +
+        "        return r;\n" +
+        "    }\n" +
+        "}";
+        const output = fresh.transpileJava(input).content;
+        // x appears only as a read inside literals; never on the left of any
+        // BinaryExpression and never reassigned. No finalX snapshot expected.
+        expect(output).not.toMatch(/final Object finalX\b/);
+        expect(output).toMatch(/put\(\s*"v",\s*x\s*\)/);
+    });
+
     // Regression (real CCXT bitmart authenticate shape): the var `timestamp` is
     // declared `const` (never reassigned in source) but later used as the left
     // side of a BinaryExpression (`timestamp + '#' + memo`). The printer flags

--- a/tests/javaTranspiler.test.ts
+++ b/tests/javaTranspiler.test.ts
@@ -1584,6 +1584,57 @@ describe('java transpiling tests', () => {
         expect(undeclared).toEqual([]);
     });
 
+    // Regression (real CCXT bitmart/bingx authenticate shape with state leak):
+    // a var is marked in ReassignedVars from a prior transpile (cross-call leak)
+    // but is `const` in the current function body. Without analyzer awareness of
+    // the leak, sibling if/else branches share the same `finalTimestamp` name,
+    // and the consumer's scope-tracking suppresses the else-branch declaration.
+    //
+    // The analyzer now consults ReassignedVars during pass 1, so leaked-in symbols
+    // also get per-branch version bumps. We simulate the leak by transpiling a
+    // priming class first.
+    test('object literal: nested if/else with ReassignedVars state leak — distinct per-branch snapshots', () => {
+        const fresh = new Transpiler();
+        // Prime ReassignedVars: T-authenticate-timestamp will get set.
+        const priming =
+        "class T {\n" +
+        "    async authenticate(type, params = {}) {\n" +
+        "        let timestamp = '0';\n" +
+        "        timestamp = timestamp + '!';\n" +
+        "        return timestamp;\n" +
+        "    }\n" +
+        "}";
+        fresh.transpileJava(priming);
+        // Target: same class+method shape but timestamp is now `const`.
+        const target =
+        "class T {\n" +
+        "    async authenticate(type, params = {}) {\n" +
+        "        if (true) {\n" +
+        "            const timestamp = '123';\n" +
+        "            const signature = 'sig';\n" +
+        "            let request = null;\n" +
+        "            if (type === 'spot') {\n" +
+        "                request = { 'args': [ timestamp, signature ] };\n" +
+        "            } else {\n" +
+        "                request = { 'args': [ timestamp, signature, 'web' ] };\n" +
+        "            }\n" +
+        "        }\n" +
+        "    }\n" +
+        "}";
+        const output = fresh.transpileJava(target).content;
+        // Each sibling branch declares its own snapshot with a distinct name.
+        expect(output).toMatch(/final Object finalTimestamp = timestamp;/);
+        expect(output).toMatch(/final Object finalTimestamp_2 = timestamp;/);
+        // Each literal references its branch's own snapshot — no out-of-scope refs.
+        expect(output).toMatch(/Arrays\.asList\(\s*finalTimestamp,/);
+        expect(output).toMatch(/Arrays\.asList\(\s*finalTimestamp_2,/);
+        // No undeclared finalXxx anywhere.
+        const allRefs = [...output.matchAll(/\b(final[A-Z]\w+)\b/g)].map(m => m[1]);
+        const allDecls = new Set([...output.matchAll(/final Object (final\w+)\s*=/g)].map(m => m[1]));
+        const undeclared = [...new Set(allRefs)].filter(r => !allDecls.has(r));
+        expect(undeclared).toEqual([]);
+    });
+
     // Regression (real CCXT parseWsTrade shape): a single if-without-else block
     // contains a HashMap literal capturing `market`; a later return-statement
     // literal also captures `market`. Pre-fix, both got the same `finalMarket`

--- a/tests/javaTranspiler.test.ts
+++ b/tests/javaTranspiler.test.ts
@@ -644,9 +644,16 @@ describe('java transpiling tests', () => {
         "    }\n" +
         "}"
         const output = transpiler.transpileJava(input).content;
-        // Each branch is a sibling scope → independent declarations
-        const declCount = (output.match(/final Object finalCode = code;/g) || []).length;
-        expect(declCount).toBe(2);
+        // Each sibling branch declares its own snapshot with a distinct version-suffixed
+        // name (finalCode in then, finalCode_2 in else). This avoids any conflict with
+        // ancestor-scope dedup if scope tracking ever leaks. Each literal references its
+        // branch's own snapshot.
+        expect(output).toMatch(/final Object finalCode = code;/);
+        expect(output).toMatch(/final Object finalCode_2 = code;/);
+        const allRefs = [...output.matchAll(/\b(final[A-Z]\w+)\b/g)].map(m => m[1]);
+        const allDecls = new Set([...output.matchAll(/final Object (final\w+)\s*=/g)].map(m => m[1]));
+        const undeclared = [...new Set(allRefs)].filter(r => !allDecls.has(r));
+        expect(undeclared).toEqual([]);
     });
 
     test('finalXxx in for-loop body and after loop — anchored at each usage', () => {
@@ -1549,22 +1556,95 @@ describe('java transpiling tests', () => {
         "    async watch(url: string, hash: string, request: any, sub: string): Promise<any> { return [url, hash, request, sub]; }\n" +
         "}";
         const output = fresh.transpileJava(input).content;
-        // The HashMap argument must read finalRawHash, not raw rawHash.
-        expect(output).toMatch(/Arrays\.asList\(\s*finalRawHash\s*\)/);
+        // The HashMap argument must read a finalRawHash variant (per-branch unique name),
+        // never raw rawHash.
+        expect(output).toMatch(/Arrays\.asList\(\s*finalRawHash(_\d+)?\s*\)/);
         expect(output).not.toMatch(/Arrays\.asList\(\s*rawHash\s*\)/);
-        // Each branch declares its own snapshot, after the reassignment.
-        expect((output.match(/final Object finalRawHash = rawHash;/g) || []).length).toBe(2);
+        // Each branch declares its own snapshot, after the reassignment. The
+        // analyzer assigns per-branch version names (finalRawHash + finalRawHash_2)
+        // so sibling branches can't suppress each other via ancestor-scope dedup.
+        expect((output.match(/final Object finalRawHash\w* = rawHash;/g) || []).length).toBe(2);
         // Snapshot must be in the same branch as the reassignment.
         const branchPattern =
-            /rawHash = Helpers\.add\([^;]*\);\s*final Object finalRawHash = rawHash;\s*return\b/g;
+            /rawHash = Helpers\.add\([^;]*\);\s*final Object finalRawHash\w* = rawHash;\s*return\b/g;
         expect((output.match(branchPattern) || []).length).toBe(2);
         // No method-scope snapshot before the if/else (which would capture null).
-        expect(output).not.toMatch(/final Object finalRawHash = rawHash;\s*if\s*\(/);
+        expect(output).not.toMatch(/final Object finalRawHash\w* = rawHash;\s*if\s*\(/);
         // every finalXxx reference must have a matching declaration
         const allRefs = [...output.matchAll(/\b(final[A-Z]\w+)\b/g)].map(m => m[1]);
         const allDecls = new Set([...output.matchAll(/final Object (final\w+)\s*=/g)].map(m => m[1]));
         const undeclared = [...new Set(allRefs)].filter(r => !allDecls.has(r));
         expect(undeclared).toEqual([]);
+    });
+
+    // Regression (real CCXT bitmart subscribe shape): the else-branch has
+    // intervening statements (const speed = ..., a nested `if (speed !== undefined)`,
+    // and a different prop key 'action' vs the if-branch's 'op') between the
+    // reassignment and the literal. The if-branch's literal captures requestOp
+    // and rawHash; the else-branch captures them again. Pre-fix output (in some
+    // environments) had the else-branch reference `finalRequestOp`/`finalRawHash`
+    // without declaring them, producing `cannot find symbol`. The analyzer's
+    // per-branch version bump fixes this by giving sibling branches distinct
+    // snapshot names.
+    test('object literal: real-bitmart-shape if/else with intervening nested if — distinct per-branch snapshots', () => {
+        const fresh = new Transpiler();
+        const input =
+        "class T {\n" +
+        "    async subscribe(unifiedName, channel, symbol, type, params = {}) {\n" +
+        "        const market = this.market(symbol);\n" +
+        "        let request = {};\n" +
+        "        let messageHash = undefined;\n" +
+        "        let rawHash = undefined;\n" +
+        "        const unsubscribe = this.safeBool(params, 'unsubscribe', false);\n" +
+        "        let prefix = '';\n" +
+        "        let requestOp = 'subscribe';\n" +
+        "        if (unsubscribe) {\n" +
+        "            params = this.omit(params, 'unsubscribe');\n" +
+        "            prefix = 'unsubscribe::';\n" +
+        "            requestOp = 'unsubscribe';\n" +
+        "        }\n" +
+        "        messageHash = unifiedName + '::' + symbol;\n" +
+        "        if (type === 'spot') {\n" +
+        "            rawHash = 'spot/' + channel + ':' + market['id'];\n" +
+        "            request = { 'op': requestOp, 'args': [ rawHash ] };\n" +
+        "        } else {\n" +
+        "            rawHash = 'futures/' + channel + ':' + market['id'];\n" +
+        "            const speed = this.safeString(params, 'speed');\n" +
+        "            if (speed !== undefined) {\n" +
+        "                params = this.omit(params, 'speed');\n" +
+        "                messageHash += ':' + speed;\n" +
+        "            }\n" +
+        "            request = { 'action': requestOp, 'args': [ rawHash ] };\n" +
+        "        }\n" +
+        "        messageHash = prefix + messageHash;\n" +
+        "        return await this.watch('url', messageHash, request, messageHash);\n" +
+        "    }\n" +
+        "    market(s) { return { 'id': s }; }\n" +
+        "    safeBool(p, k, d) { return d; }\n" +
+        "    safeString(p, k) { return undefined; }\n" +
+        "    omit(p, k) { return p; }\n" +
+        "    async watch(url, hash, req, sub) { return [url, hash, req, sub]; }\n" +
+        "}";
+        const output = fresh.transpileJava(input).content;
+        // Each branch declares its own snapshot for both rawHash and requestOp.
+        expect((output.match(/final Object finalRawHash\w* = rawHash;/g) || []).length).toBe(2);
+        expect((output.match(/final Object finalRequestOp\w* = requestOp;/g) || []).length).toBe(2);
+        // If-branch and else-branch use DIFFERENT snapshot names — both halves of
+        // the version-suffix pair must be present.
+        expect(output).toMatch(/final Object finalRawHash = rawHash;/);
+        expect(output).toMatch(/final Object finalRawHash_2 = rawHash;/);
+        expect(output).toMatch(/final Object finalRequestOp = requestOp;/);
+        expect(output).toMatch(/final Object finalRequestOp_2 = requestOp;/);
+        // The else-branch literal references the _2 names (the if-branch's names
+        // are scoped to its block). No undeclared finalXxx anywhere.
+        const allRefs = [...output.matchAll(/\b(final[A-Z]\w+)\b/g)].map(m => m[1]);
+        const allDecls = new Set([...output.matchAll(/final Object (final\w+)\s*=/g)].map(m => m[1]));
+        const undeclared = [...new Set(allRefs)].filter(r => !allDecls.has(r));
+        expect(undeclared).toEqual([]);
+        // Each finalRawHash variant declaration must be paired with a usage
+        // inside an Arrays.asList (the anonymous-inner-class HashMap capture).
+        expect(output).toMatch(/Arrays\.asList\(\s*finalRawHash\s*\)/);
+        expect(output).toMatch(/Arrays\.asList\(\s*finalRawHash_2\s*\)/);
     });
 
     // Regression (user-reported reproducer): free-function shape with default-value
@@ -1586,10 +1666,13 @@ describe('java transpiling tests', () => {
         "    return request;\n" +
         "}";
         const output = fresh.transpileJava(input).content;
-        // Both branches declare a per-branch snapshot.
-        expect((output.match(/final Object finalRawHash = rawHash;/g) || []).length).toBe(2);
-        // Both branches read finalRawHash inside the HashMap; no raw rawHash leaks into the literal.
-        expect((output.match(/Arrays\.asList\(\s*finalRawHash\s*\)/g) || []).length).toBe(2);
+        // Each branch declares its own per-branch snapshot. With the analyzer's
+        // sibling-branch version bump, the if-branch gets `finalRawHash` and the
+        // else-branch gets `finalRawHash_2` (or similar) — distinct names per
+        // branch so neither suppresses the other.
+        expect((output.match(/final Object finalRawHash\w* = rawHash;/g) || []).length).toBe(2);
+        // Both branches reference a finalRawHash variant; no raw rawHash leaks.
+        expect((output.match(/Arrays\.asList\(\s*finalRawHash\w*\s*\)/g) || []).length).toBe(2);
         expect(output).not.toMatch(/Arrays\.asList\(\s*rawHash\s*\)/);
         // No `cannot find symbol`: every finalXxx reference has a declaration.
         const allRefs = [...output.matchAll(/\b(final[A-Z]\w+)\b/g)].map(m => m[1]);
@@ -1617,8 +1700,10 @@ describe('java transpiling tests', () => {
         "    return request;\n" +
         "}";
         const output = fresh.transpileJava(input).content;
-        expect((output.match(/final Object finalRawHash = rawHash;/g) || []).length).toBe(2);
-        expect((output.match(/final Object finalOp = op;/g) || []).length).toBe(2);
+        // Both branches declare their own snapshots for both vars (with distinct
+        // version-suffixed names for the sibling branch).
+        expect((output.match(/final Object finalRawHash\w* = rawHash;/g) || []).length).toBe(2);
+        expect((output.match(/final Object finalOp\w* = op;/g) || []).length).toBe(2);
         const allRefs = [...output.matchAll(/\b(final[A-Z]\w+)\b/g)].map(m => m[1]);
         const allDecls = new Set([...output.matchAll(/final Object (final\w+)\s*=/g)].map(m => m[1]));
         const undeclared = [...new Set(allRefs)].filter(r => !allDecls.has(r));
@@ -1648,21 +1733,20 @@ describe('java transpiling tests', () => {
         "    }\n" +
         "}";
         const output = fresh.transpileJava(input).content;
-        // The literal must read from finalRawHash, not raw rawHash.
-        expect(output).toMatch(/Arrays\.asList\(\s*finalRawHash\s*\)/);
+        // The literal must read from a finalRawHash variant, not raw rawHash.
+        expect(output).toMatch(/Arrays\.asList\(\s*finalRawHash\w*\s*\)/);
         expect(output).not.toMatch(/Arrays\.asList\(\s*rawHash\s*\)/);
-        // The snapshot must be inside each branch (after the reassignment),
-        // not at method scope before the if. There are two branches → two snapshots.
-        expect((output.match(/final Object finalRawHash = rawHash;/g) || []).length).toBe(2);
+        // Each branch declares its own snapshot, after the reassignment, not at
+        // method scope before the if. Names are per-branch unique
+        // (finalRawHash + finalRawHash_2) so ancestor-scope dedup can't suppress.
+        expect((output.match(/final Object finalRawHash\w* = rawHash;/g) || []).length).toBe(2);
         // The snapshot must come AFTER the corresponding reassignment in each branch.
-        // We assert structurally: each snapshot is preceded by a `rawHash = Helpers.add(...)`
-        // line, with no intervening `if (` on the same path.
         const branchPattern =
-            /rawHash = Helpers\.add\([^;]*\);\s*final Object finalRawHash = rawHash;\s*request = new java\.util\.HashMap/g;
+            /rawHash = Helpers\.add\([^;]*\);\s*final Object finalRawHash\w* = rawHash;\s*request = new java\.util\.HashMap/g;
         expect((output.match(branchPattern) || []).length).toBe(2);
         // Must NOT emit a method-scope snapshot before the if/else
         // (which the pre-fix output did, capturing the null seed value).
-        expect(output).not.toMatch(/final Object finalRawHash = rawHash;\s*if\s*\(/);
+        expect(output).not.toMatch(/final Object finalRawHash\w* = rawHash;\s*if\s*\(/);
         // every finalXxx reference must have a matching declaration
         const allRefs = [...output.matchAll(/\b(final[A-Z]\w+)\b/g)].map(m => m[1]);
         const allDecls = new Set([...output.matchAll(/final Object (final\w+)\s*=/g)].map(m => m[1]));

--- a/tests/javaTranspiler.test.ts
+++ b/tests/javaTranspiler.test.ts
@@ -1656,6 +1656,59 @@ describe('java transpiling tests', () => {
         expect(undeclared).toEqual([]);
     });
 
+    // Coverage gap: try/catch are sibling scopes like if/else. A captured
+    // reassigned symbol in both blocks gets the same un-suffixed name without
+    // intervention, leaving the catch block vulnerable to ancestor-scope dedup
+    // leak in the same way as the if/else case.
+    test('object literal: try/catch sibling blocks — distinct per-block snapshots', () => {
+        const fresh = new Transpiler();
+        const input =
+        "class T {\n" +
+        "    async f() {\n" +
+        "        let x = '';\n" +
+        "        x = x + '!';\n" +
+        "        let r = undefined;\n" +
+        "        try {\n" +
+        "            r = { 'v': x };\n" +
+        "        } catch (e) {\n" +
+        "            r = { 'v': x };\n" +
+        "        }\n" +
+        "        return r;\n" +
+        "    }\n" +
+        "}";
+        const output = fresh.transpileJava(input).content;
+        expect(output).toMatch(/final Object finalX = x;/);
+        expect(output).toMatch(/final Object finalX_2 = x;/);
+        const allRefs = [...output.matchAll(/\b(final[A-Z]\w+)\b/g)].map(m => m[1]);
+        const allDecls = new Set([...output.matchAll(/final Object (final\w+)\s*=/g)].map(m => m[1]));
+        const undeclared = [...new Set(allRefs)].filter(r => !allDecls.has(r));
+        expect(undeclared).toEqual([]);
+    });
+
+    // Ternary captures: both branches of a ConditionalExpression evaluate in
+    // the parent scope, so a single snapshot at parent scope serves both. No
+    // sibling-scope hazard here — just locks in the expected single-decl shape.
+    test('object literal: ternary branches share parent-scope snapshot — single declaration', () => {
+        const fresh = new Transpiler();
+        const input =
+        "class T {\n" +
+        "    async f(type) {\n" +
+        "        let x = '';\n" +
+        "        x = x + '!';\n" +
+        "        const r = (type === 'a') ? { 'v': x } : { 'v': x };\n" +
+        "        return r;\n" +
+        "    }\n" +
+        "}";
+        const output = fresh.transpileJava(input).content;
+        // Both ternary branches share one snapshot at the enclosing scope.
+        expect((output.match(/final Object finalX = x;/g) || []).length).toBe(1);
+        expect((output.match(/put\(\s*"v",\s*finalX\s*\)/g) || []).length).toBe(2);
+        const allRefs = [...output.matchAll(/\b(final[A-Z]\w+)\b/g)].map(m => m[1]);
+        const allDecls = new Set([...output.matchAll(/final Object (final\w+)\s*=/g)].map(m => m[1]));
+        const undeclared = [...new Set(allRefs)].filter(r => !allDecls.has(r));
+        expect(undeclared).toEqual([]);
+    });
+
     // Negative regression: a var that is truly never reassigned and only read
     // outside any BinaryExpression context must NOT get a snapshot in the
     // captured literal. Catches accidental over-eager versioning from the

--- a/tests/javaTranspiler.test.ts
+++ b/tests/javaTranspiler.test.ts
@@ -622,13 +622,20 @@ describe('java transpiling tests', () => {
         "    }\n" +
         "}"
         const output = transpiler.transpileJava(input).content;
-        // Two usage sites in distinct scopes → two anchored declarations
-        const declCount = (output.match(/final Object finalMarketId = marketId;/g) || []).length;
-        expect(declCount).toBe(2);
-        // all put() calls should use finalMarketId
+        // Two usage sites in distinct scopes → two anchored declarations. The
+        // analyzer's per-block version bump gives each region a distinct name
+        // (finalMarketId inside the if, finalMarketId_2 after the if) so the
+        // ancestor-scope dedup can never suppress the outer declaration.
+        expect((output.match(/final Object finalMarketId\w* = marketId;/g) || []).length).toBe(2);
+        // each put() must reference a declared finalMarketId variant
         const putMatches = output.match(/put\(\s*"symbol",\s*(\w+)\s*\)/g) || [];
         expect(putMatches.length).toBe(2);
-        putMatches.forEach(m => expect(m).toContain('finalMarketId'));
+        putMatches.forEach(m => expect(m).toMatch(/finalMarketId\w*/));
+        // every finalXxx reference has a matching declaration (no cannot-find-symbol)
+        const allRefs = [...output.matchAll(/\b(final[A-Z]\w+)\b/g)].map(m => m[1]);
+        const allDecls = new Set([...output.matchAll(/final Object (final\w+)\s*=/g)].map(m => m[1]));
+        const undeclared = [...new Set(allRefs)].filter(r => !allDecls.has(r));
+        expect(undeclared).toEqual([]);
     });
 
     test('finalXxx in if/else branches — each branch gets its own anchored declaration', () => {
@@ -1571,6 +1578,44 @@ describe('java transpiling tests', () => {
         // No method-scope snapshot before the if/else (which would capture null).
         expect(output).not.toMatch(/final Object finalRawHash\w* = rawHash;\s*if\s*\(/);
         // every finalXxx reference must have a matching declaration
+        const allRefs = [...output.matchAll(/\b(final[A-Z]\w+)\b/g)].map(m => m[1]);
+        const allDecls = new Set([...output.matchAll(/final Object (final\w+)\s*=/g)].map(m => m[1]));
+        const undeclared = [...new Set(allRefs)].filter(r => !allDecls.has(r));
+        expect(undeclared).toEqual([]);
+    });
+
+    // Regression (real CCXT parseWsTrade shape): a single if-without-else block
+    // contains a HashMap literal capturing `market`; a later return-statement
+    // literal also captures `market`. Pre-fix, both got the same `finalMarket`
+    // name and the second emission was suppressed by ancestor-scope dedup in
+    // some environments — leaving the return literal with an undeclared reference.
+    // The analyzer's per-block version bump gives each region a distinct name
+    // (finalMarket inside the if, finalMarket_2 after the if).
+    test('object literal: if-without-else inner capture + post-if outer capture — distinct snapshots', () => {
+        const fresh = new Transpiler();
+        const input =
+        "class T {\n" +
+        "    parseWsTrade(trade, market = undefined) {\n" +
+        "        market = this.safeMarket(this.safeString(trade, 'code'), market);\n" +
+        "        let fee = null;\n" +
+        "        const feeCost = this.safeString(trade, 'paid_fee');\n" +
+        "        if (feeCost !== undefined) {\n" +
+        "            fee = { 'currency': market['quote'], 'cost': feeCost };\n" +
+        "        }\n" +
+        "        return this.safeTrade({ 'symbol': market['symbol'], 'fee': fee });\n" +
+        "    }\n" +
+        "    safeMarket(a, b) { return b; }\n" +
+        "    safeString(o, k) { return undefined; }\n" +
+        "    safeTrade(t) { return t; }\n" +
+        "}";
+        const output = fresh.transpileJava(input).content;
+        // Both regions declare their own snapshot with distinct names.
+        expect(output).toMatch(/final Object finalMarket = market;/);
+        expect(output).toMatch(/final Object finalMarket_2 = market;/);
+        // The if-block literal references finalMarket; the return literal references finalMarket_2.
+        expect(output).toMatch(/put\(\s*"currency",\s*Helpers\.GetValue\(finalMarket,/);
+        expect(output).toMatch(/put\(\s*"symbol",\s*Helpers\.GetValue\(finalMarket_2,/);
+        // No undeclared finalXxx references.
         const allRefs = [...output.matchAll(/\b(final[A-Z]\w+)\b/g)].map(m => m[1]);
         const allDecls = new Set([...output.matchAll(/final Object (final\w+)\s*=/g)].map(m => m[1]));
         const undeclared = [...new Set(allRefs)].filter(r => !allDecls.has(r));

--- a/tests/javaTranspiler.test.ts
+++ b/tests/javaTranspiler.test.ts
@@ -1584,6 +1584,51 @@ describe('java transpiling tests', () => {
         expect(undeclared).toEqual([]);
     });
 
+    // Regression (real CCXT bitmart authenticate shape): the var `timestamp` is
+    // declared `const` (never reassigned in source) but later used as the left
+    // side of a BinaryExpression (`timestamp + '#' + memo`). The printer flags
+    // this in ReassignedVars mid-print, then substitutes `timestamp` → `finalTimestamp`
+    // in every literal that captures it. Without analyzer awareness, both if/else
+    // branches share the same `finalTimestamp` name and the consumer's scope
+    // tracking can suppress the else-branch declaration.
+    //
+    // Pass 1 of the analyzer now mirrors the printer's heuristic: any
+    // BinaryExpression with an Identifier left flags the symbol, so the version
+    // bump fires for these too.
+    test('object literal: var read in BinaryExpression then captured in if/else literals — distinct per-branch snapshots', () => {
+        const fresh = new Transpiler();
+        const input =
+        "class T {\n" +
+        "    async authenticate(type) {\n" +
+        "        const authenticated = this.safeValue(this.client.subscriptions, 'authenticated');\n" +
+        "        if (authenticated === undefined) {\n" +
+        "            const timestamp = '123';\n" +
+        "            const auth = timestamp + '#' + 'memo';\n" +
+        "            let request = undefined;\n" +
+        "            if (type === 'spot') {\n" +
+        "                request = { 'args': [ this.apiKey, timestamp, auth ] };\n" +
+        "            } else {\n" +
+        "                request = { 'args': [ this.apiKey, timestamp, auth, 'web' ] };\n" +
+        "            }\n" +
+        "        }\n" +
+        "    }\n" +
+        "    apiKey = 'k';\n" +
+        "    client = { subscriptions: {} };\n" +
+        "    safeValue(o, k) { return undefined; }\n" +
+        "}";
+        const output = fresh.transpileJava(input).content;
+        expect(output).toMatch(/final Object finalTimestamp = timestamp;/);
+        expect(output).toMatch(/final Object finalTimestamp_2 = timestamp;/);
+        // Each branch references its own snapshot, no cross-scope leaks.
+        expect(output).toMatch(/Arrays\.asList\([^)]*finalTimestamp,[^)]*\)/);
+        expect(output).toMatch(/Arrays\.asList\([^)]*finalTimestamp_2,[^)]*\)/);
+        // No undeclared finalXxx anywhere.
+        const allRefs = [...output.matchAll(/\b(final[A-Z]\w+)\b/g)].map(m => m[1]);
+        const allDecls = new Set([...output.matchAll(/final Object (final\w+)\s*=/g)].map(m => m[1]));
+        const undeclared = [...new Set(allRefs)].filter(r => !allDecls.has(r));
+        expect(undeclared).toEqual([]);
+    });
+
     // Regression (real CCXT bitmart/bingx authenticate shape with state leak):
     // a var is marked in ReassignedVars from a prior transpile (cross-call leak)
     // but is `const` in the current function body. Without analyzer awareness of

--- a/tests/javaTranspiler.test.ts
+++ b/tests/javaTranspiler.test.ts
@@ -1567,6 +1567,64 @@ describe('java transpiling tests', () => {
         expect(undeclared).toEqual([]);
     });
 
+    // Regression (user-reported reproducer): free-function shape with default-value
+    // param `op = 'subscribe'`. Asserts both branches emit `final Object finalRawHash`
+    // — the user's report claimed the else branch was missing its snapshot.
+    test('object literal: free-function default-param subscribe shape — both branches declare', () => {
+        const fresh = new Transpiler();
+        const input =
+        "async function subscribe (type, channel, symbol, op = 'subscribe') {\n" +
+        "    let request = {};\n" +
+        "    let rawHash = undefined;\n" +
+        "    if (type === 'spot') {\n" +
+        "        rawHash = 'spot/' + channel + ':' + symbol;\n" +
+        "        request = { 'op': op, 'args': [ rawHash ] };\n" +
+        "    } else {\n" +
+        "        rawHash = 'futures/' + channel + ':' + symbol;\n" +
+        "        request = { 'op': op, 'args': [ rawHash ] };\n" +
+        "    }\n" +
+        "    return request;\n" +
+        "}";
+        const output = fresh.transpileJava(input).content;
+        // Both branches declare a per-branch snapshot.
+        expect((output.match(/final Object finalRawHash = rawHash;/g) || []).length).toBe(2);
+        // Both branches read finalRawHash inside the HashMap; no raw rawHash leaks into the literal.
+        expect((output.match(/Arrays\.asList\(\s*finalRawHash\s*\)/g) || []).length).toBe(2);
+        expect(output).not.toMatch(/Arrays\.asList\(\s*rawHash\s*\)/);
+        // No `cannot find symbol`: every finalXxx reference has a declaration.
+        const allRefs = [...output.matchAll(/\b(final[A-Z]\w+)\b/g)].map(m => m[1]);
+        const allDecls = new Set([...output.matchAll(/final Object (final\w+)\s*=/g)].map(m => m[1]));
+        const undeclared = [...new Set(allRefs)].filter(r => !allDecls.has(r));
+        expect(undeclared).toEqual([]);
+    });
+
+    // Regression: same shape as above but with `op` actually reassigned inside the
+    // function — so `op` itself enters ReassignedVars and needs a per-branch snapshot too.
+    test('object literal: free-function with op reassigned + rawHash in if/else — both branches declare both', () => {
+        const fresh = new Transpiler();
+        const input =
+        "async function subscribe (type, channel, symbol, op = 'subscribe') {\n" +
+        "    op = op.toLowerCase();\n" +
+        "    let request = {};\n" +
+        "    let rawHash = undefined;\n" +
+        "    if (type === 'spot') {\n" +
+        "        rawHash = 'spot/' + channel + ':' + symbol;\n" +
+        "        request = { 'op': op, 'args': [ rawHash ] };\n" +
+        "    } else {\n" +
+        "        rawHash = 'futures/' + channel + ':' + symbol;\n" +
+        "        request = { 'op': op, 'args': [ rawHash ] };\n" +
+        "    }\n" +
+        "    return request;\n" +
+        "}";
+        const output = fresh.transpileJava(input).content;
+        expect((output.match(/final Object finalRawHash = rawHash;/g) || []).length).toBe(2);
+        expect((output.match(/final Object finalOp = op;/g) || []).length).toBe(2);
+        const allRefs = [...output.matchAll(/\b(final[A-Z]\w+)\b/g)].map(m => m[1]);
+        const allDecls = new Set([...output.matchAll(/final Object (final\w+)\s*=/g)].map(m => m[1]));
+        const undeclared = [...new Set(allRefs)].filter(r => !allDecls.has(r));
+        expect(undeclared).toEqual([]);
+    });
+
     // Regression: bitmart-style subscribe helper. `rawHash` is declared with
     // `undefined`, then reassigned inside each if/else branch and immediately
     // used inside a HashMap literal in that same branch. The final-var snapshot


### PR DESCRIPTION
## Summary

`printReturnStatement` only matched `ObjectLiteralExpression`, `CallExpression`, and `ArrayLiteralExpression` at the top level — so `return await this.x(..., {literal capturing reassigned var}, ...)` slipped through entirely. The HashMap literal printed with raw (non-final) identifiers and no `final Object finalXxx = x;` snapshot, which javac rejects on the anonymous-inner-class capture.

Switched to the existing `collectCapturingObjectLiterals` helper (already used by `printVariableDeclarationList` for the same reason). It descends through any wrapper expression — `AwaitExpression`, `ParenthesizedExpression`, `ConditionalExpression`, `NewExpression`, nested `CallExpression` arguments, `ArrayLiteralExpression` elements — and surfaces every literal that would produce an anonymous-inner-class capture in Java.

## Real-world incidence

CCXT WS subscribe helper shape (`ts/src/pro/bitmart.ts` and siblings):

```ts
if (type === 'spot') {
    rawHash = 'spot/ticker:' + symbol;
    return await this.watch('url', hash, { 'args': [rawHash] }, rawHash);
} else {
    rawHash = 'futures/ticker:' + symbol;
    return await this.watch('url', hash, { 'args': [rawHash] }, rawHash);
}
```

**Before:** each branch emits `Arrays.asList(rawHash)` inside the anon-inner-class with no snapshot — won't compile. CCXT had been compensating with a `hoistFinalVarsAcrossIfElse` post-processor that hoisted a single `final Object finalRawHash = rawHash;` to method scope, which captured the pre-assignment `null` and produced `args:[null]` / `args:[""]` at runtime on bitmart/bingx/bydfi/upbit/whitebit WS sweeps.

**After:** each branch emits its own `final Object finalRawHash = rawHash;` after the reassignment, and the HashMap reads from `finalRawHash`. The post-processor can be removed downstream.

## Test plan

- [x] Added regression test for the return-await-call shape (the actual bug)
- [x] Added regression test for the assignment-form spec reproducer (`request = {...}` in if/else) — already correct on master, locked in here
- [x] Full Java suite: 76/76
- [x] Full repo suite: 252/252

## Downstream

After this lands and ships, CCXT should:
1. Bump the ast-transpiler dep.
2. **Delete `hoistFinalVarsAcrossIfElse`** — it would now actively corrupt correct output by hoisting a null-capturing snapshot over the per-branch ones.
3. Re-run the WS sweeps on bitmart/bingx/bydfi/upbit/whitebit — the `args:[null]` / `args:[""]` failures should clear.