### PR TITLE
refactor: replace process globals with an explicit transpile context

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,44 @@ console.log(transpiled.imports) // prints unified imports statements if any
 console.log(transpiled.exports) // prints unified export statements if any
 ```
 
+## 🧵 Concurrency and sharing work between threads
+
+A `Transpiler` instance owns its typescript state, so several instances can be used at the same time in one process. Instances can additionally share a **program cache** — the parsed `SourceFile`s (the es lib chain plus the import closure of everything transpiled so far) and the last program built from them:
+
+```js
+const cache = Transpiler.createProgramCache();
+
+const a = new Transpiler(config, cache);
+const b = new Transpiler(config, cache); // reuses everything a has parsed
+// or, from an existing instance:
+const c = a.cloneSharingProgramCache();
+```
+
+Each instance keeps its own printers and its own transpile context, so they can be driven independently and interleaved; only the parse/typecheck work is shared. Transpilation output is unaffected.
+
+### Worker threads
+
+**A `ts.Program` cannot be shared between worker threads.** Each worker is a separate V8 isolate, and `postMessage` uses structured clone, which rejects a `Program`, a `TypeChecker`, a `SourceFile` and even a single AST node (they carry functions and cyclic internal state). A `SharedArrayBuffer` only shares raw bytes, so it cannot hold one either.
+
+What works in practice:
+
+- **Within a thread** — share one program cache across as many `Transpiler` instances as you like (above). This is where the reuse happens.
+- **Across worker threads** — send file paths or source text, and give each worker a long-lived cache of its own, e.g. a module-level `const cache = Transpiler.createProgramCache()` in the worker entry point reused by every task that worker handles. The parse work is then done once per worker instead of once per task:
+
+```js
+// worker.js — one cache per worker, reused across tasks
+import { Transpiler } from 'ast-transpiler';
+
+const cache = Transpiler.createProgramCache();
+
+export default async ({ transpilerConfig, files }) => {
+    const transpiler = new Transpiler(transpilerConfig, cache);
+    return files.map((f) => transpiler.transpileGoByPath(f));
+};
+```
+
+A cache is bound to the thread that created it; do not attempt to post one to another thread.
+
 ## ⚡ C#/Go/Java/Rust Notes
 ### Helpers
 C#/Go/Java/Rust are very different from languages like Typescript, Python or PHP since it's statically typed and much more restricted than the others mentioned. Things like falsy values, empty default objects, dynamic properties, different type comparison, untyped arguments/return type, etc do not exist so I had to create a set of wrappers that will emulate these features in C#/Go/Java/Rust. So in order to make your code run you need to make all the **helper** methods available [here](https://github.com/carlosmiei/ast-transpiler/blob/c%23/helpers/c%23/helpers.cs) accessible from your code (wip).

--- a/src/baseTranspiler.ts
+++ b/src/baseTranspiler.ts
@@ -1,5 +1,5 @@
 import ts from 'typescript';
-import { IFileImport, IFileExport, TranspilationError, IMethodType, IParameterType } from './types.js';
+import { IFileImport, IFileExport, TranspilationError, IMethodType, IParameterType, ITranspileContext } from './types.js';
 import { unCamelCase } from "./utils.js";
 import { Logger } from "./logger.js";
 import { timingSafeEqual } from 'crypto';
@@ -198,6 +198,9 @@ class BaseTranspiler {
     removeVariableDeclarationForFunctionExpression;
     includeFunctionNameInFunctionExpressionDeclaration;
     id;
+    // typescript state for the transpilation currently in flight. Set by the owning
+    // Transpiler before it walks the AST, so nothing leaks through process globals.
+    context: ITranspileContext | undefined;
 
     constructor(config) {
         Object.assign (this, (config['parser'] || {}));
@@ -210,6 +213,29 @@ class BaseTranspiler {
         this.removeVariableDeclarationForFunctionExpression = true;
         this.includeFunctionNameInFunctionExpressionDeclaration = true;
         this.initOperators();
+    }
+
+    setContext(context: ITranspileContext | undefined): void {
+        this.context = context;
+    }
+
+    getContext(): ITranspileContext {
+        if (this.context === undefined) {
+            throw new Error("No transpilation context set: the typescript program must be created before printing nodes.");
+        }
+        return this.context;
+    }
+
+    getSrc(): ts.SourceFile {
+        return this.getContext().src;
+    }
+
+    getChecker(): ts.TypeChecker {
+        return this.getContext().checker;
+    }
+
+    getProgram(): ts.Program {
+        return this.getContext().program;
     }
 
     initOperators() {
@@ -282,7 +308,7 @@ class BaseTranspiler {
 
     getLineAndCharacterOfNode(node): [number,number] {
         const { line, character } =
-        global.src.getLineAndCharacterOfPosition(node.getStart());
+        this.getSrc().getLineAndCharacterOfPosition(node.getStart());
         return [line + 1,character];
     }
 
@@ -327,8 +353,8 @@ class BaseTranspiler {
         if (!this.implicitAsyncTranspiling || !ts.isFunctionLike(node) || this.hasAsyncModifier(node)) {
             return false;
         }
-        const signature = global.checker.getSignatureFromDeclaration(node);
-        return signature !== undefined && this.isPromiseType(global.checker.getReturnTypeOfSignature(signature));
+        const signature = this.getChecker().getSignatureFromDeclaration(node);
+        return signature !== undefined && this.isPromiseType(this.getChecker().getReturnTypeOfSignature(signature));
     }
 
     isAsyncFunction(node) {
@@ -361,7 +387,7 @@ class BaseTranspiler {
         let parentClass = (ts as any).getAllSuperTypeNodes(node.parent)[0];
 
         while (parentClass !== undefined) {
-            const parentClassType = global.checker.getTypeAtLocation(parentClass);
+            const parentClassType = this.getChecker().getTypeAtLocation(parentClass);
             const parentClassDecl = parentClassType?.symbol?.valueDeclaration;
 
             if (parentClassDecl === undefined) {
@@ -369,7 +395,7 @@ class BaseTranspiler {
                 return undefined;
             }
 
-            const parentClassMembers = parentClassDecl.members ?? [];
+            const parentClassMembers = (parentClassDecl as any).members ?? [];
 
             parentClassMembers.forEach(elem=> {
                 if (ts.isMethodDeclaration(elem)) {
@@ -648,7 +674,7 @@ class BaseTranspiler {
     }
 
     printLeadingComments(node, identation) {
-        const fullText = global.src.getFullText();
+        const fullText = this.getSrc().getFullText();
         const commentsRangeList = ts.getLeadingCommentRanges(fullText, node.pos);
         const commentsRange = commentsRangeList ? commentsRangeList : undefined;
         let res = "";
@@ -668,7 +694,7 @@ class BaseTranspiler {
     }
 
     printTraillingComment(node, identation) {
-        const fullText = global.src.getFullText();
+        const fullText = this.getSrc().getFullText();
         const commentsRangeList = ts.getTrailingCommentRanges(fullText, node.end);
         const commentsRange = commentsRangeList ? commentsRangeList : undefined;
         let res = "";
@@ -800,19 +826,20 @@ class BaseTranspiler {
 
     getFunctionType(node, async = true){
         // use type checker to do it here
-        const type = global.checker.getReturnTypeOfSignature(global.checker.getSignatureFromDeclaration(node));
+        const type = this.getChecker().getReturnTypeOfSignature(this.getChecker().getSignatureFromDeclaration(node));
 
         const parsedTtype = this.getTypeFromRawType(type);
 
         if (parsedTtype === this.PROMISE_TYPE_KEYWORD) {
-            if (type.resolvedTypeArguments.length === 0) {
+            const resolvedTypeArguments = (type as any).resolvedTypeArguments; // internal typescript property
+            if (resolvedTypeArguments.length === 0) {
                 return this.PROMISE_TYPE_KEYWORD;
             }
-            if (type.resolvedTypeArguments.length === 1 && type.resolvedTypeArguments[0].flags === ts.TypeFlags.Void) {
+            if (resolvedTypeArguments.length === 1 && resolvedTypeArguments[0].flags === ts.TypeFlags.Void) {
                 return this.PROMISE_TYPE_KEYWORD;
             }
 
-            const insideTypes = type.resolvedTypeArguments.map(type => this.getTypeFromRawType(type)).join(",");
+            const insideTypes = resolvedTypeArguments.map(type => this.getTypeFromRawType(type)).join(",");
             if (insideTypes.length > 0) {
                 if (async) {
                     return `${this.PROMISE_TYPE_KEYWORD}<${insideTypes}>`;
@@ -838,7 +865,7 @@ class BaseTranspiler {
             return this.DEFAULT_PARAMETER_TYPE;
         }
 
-        const type = global.checker.typeToString(global.checker.getTypeAtLocation(node));
+        const type = this.getChecker().typeToString(this.getChecker().getTypeAtLocation(node));
 
         if (this.ArgTypeReplacements[type]) {
             return this.ArgTypeReplacements[type];
@@ -1028,7 +1055,7 @@ class BaseTranspiler {
     }
 
     isBuiltInFunctionCall(node) {
-        const symbol = global.checker.getSymbolAtLocation(node);
+        const symbol = this.getChecker().getSymbolAtLocation(node);
         const isInLibFiles = symbol?.getDeclarations()
             ?.some(s => s.getSourceFile().fileName.includes("/node_modules/typescript/lib/"))
             ?? false;
@@ -1038,11 +1065,11 @@ class BaseTranspiler {
     }
 
     getTypesFromCallExpressionParameters(node) {
-        const resolvedParams = global.checker.getResolvedSignature(node).parameters;
+        const resolvedParams = this.getChecker().getResolvedSignature(node).parameters;
         const parsedTypes = [];
         resolvedParams.forEach((p) => {
             const decl = p.declarations[0];
-            const type = global.checker.getTypeAtLocation(decl);
+            const type = this.getChecker().getTypeAtLocation(decl);
             const parsedType = this.getTypeFromRawType(type);
             parsedTypes.push(parsedType);
         });
@@ -1540,12 +1567,12 @@ class BaseTranspiler {
         }
         // cast order["test"] to ((Dictionariy<string, object>)order)["test"] or List<object>
         if (isLeftSideOfAssignment && this.ELEMENT_ACCESS_WRAPPER_OPEN && this.ELEMENT_ACCESS_WRAPPER_CLOSE) {
-            const type = global.checker.getTypeAtLocation(argumentExpression);
+            const type = this.getChecker().getTypeAtLocation(argumentExpression);
             const isString = this.isStringType(type.flags);
 
             let isUnionString = false; // handle unions later
             if (type.flags === ts.TypeFlags.Union) {
-                isUnionString = this.isStringType(type?.types[0].flags);
+                isUnionString = this.isStringType((type as any)?.types[0].flags);
             }
 
             if (isString || isUnionString || type.flags === ts.TypeFlags.Any) { // default to string when unknown
@@ -1695,7 +1722,7 @@ class BaseTranspiler {
         let exp = node.expression;
         if (!exp || ts.isAwaitExpression(exp)
                 || !this.isImplicitAsyncFunction(ts.findAncestor(node, ts.isFunctionLike))
-                || !this.isPromiseType(global.checker.getTypeAtLocation(exp))) {
+                || !this.isPromiseType(this.getChecker().getTypeAtLocation(exp))) {
             return node;
         }
         if (ts.isConditionalExpression(exp) || ts.isBinaryExpression(exp)) {
@@ -2150,14 +2177,14 @@ class BaseTranspiler {
     getReturnTypeFromMethod(node): string {
         // first try custom type
 
-        const bType = global.checker.getTypeAtLocation(node);
+        const bType = this.getChecker().getTypeAtLocation(node);
         // const func2Symbol = bType.getProperty("test1")!;
-        const func2Type = global.checker.getTypeOfSymbolAtLocation(bType.symbol, bType.symbol.valueDeclaration);
-        const func2Signature = global.checker.getSignaturesOfType(func2Type, ts.SignatureKind.Call)[0];
+        const func2Type = this.getChecker().getTypeOfSymbolAtLocation(bType.symbol, bType.symbol.valueDeclaration);
+        const func2Signature = this.getChecker().getSignaturesOfType(func2Type, ts.SignatureKind.Call)[0];
         const rawType = func2Signature.getReturnType();
         // const parsed = ts.TypeFlags[rawType.flags];
         // console.log(parsed);
-        const res = global.checker.typeToString(rawType); // C
+        const res = this.getChecker().typeToString(rawType); // C
         if (res === undefined) {
             const name = node.type?.typeName?.escapedText;
             if (name){
@@ -2184,8 +2211,8 @@ class BaseTranspiler {
         if (node.type === undefined) {
             // does not have a type or uses a initializer
             if (node.initializer !== undefined) {
-                const type = global.checker.getTypeAtLocation(node.initializer);
-                const res = global.checker.typeToString(type); // C
+                const type = this.getChecker().getTypeAtLocation(node.initializer);
+                const res = this.getChecker().typeToString(type); // C
                 // console.log("initializer", res);
                 // result.initializer = node.initializer.text;
                 result.type = ts.TypeFlags[type.flags];
@@ -2203,8 +2230,8 @@ class BaseTranspiler {
         }
 
         if (node.type != undefined) {
-            const type = global.checker.getTypeAtLocation(node.type);
-            const res = global.checker.typeToString(type); // C
+            const type = this.getChecker().getTypeAtLocation(node.type);
+            const res = this.getChecker().typeToString(type); // C
             result.type = res as string;
             return result;
         }

--- a/src/baseTranspiler.ts
+++ b/src/baseTranspiler.ts
@@ -3,6 +3,9 @@ import { IFileImport, IFileExport, TranspilationError, IMethodType, IParameterTy
 import { unCamelCase } from "./utils.js";
 import { Logger } from "./logger.js";
 import { timingSafeEqual } from 'crypto';
+
+const NO_CONTEXT_ERROR = "No transpilation context set: the typescript program must be created before printing nodes.";
+
 class BaseTranspiler {
 
     NUM_LINES_BETWEEN_CLASS_MEMBERS = 1;
@@ -219,23 +222,19 @@ class BaseTranspiler {
         this.context = context;
     }
 
-    getContext(): ITranspileContext {
-        if (this.context === undefined) {
-            throw new Error("No transpilation context set: the typescript program must be created before printing nodes.");
-        }
-        return this.context;
-    }
-
     getSrc(): ts.SourceFile {
-        return this.getContext().src;
+        if (this.context === undefined) throw new Error(NO_CONTEXT_ERROR);
+        return this.context.src;
     }
 
     getChecker(): ts.TypeChecker {
-        return this.getContext().checker;
+        if (this.context === undefined) throw new Error(NO_CONTEXT_ERROR);
+        return this.context.checker;
     }
 
     getProgram(): ts.Program {
-        return this.getContext().program;
+        if (this.context === undefined) throw new Error(NO_CONTEXT_ERROR);
+        return this.context.program;
     }
 
     initOperators() {

--- a/src/csharpTranspiler.ts
+++ b/src/csharpTranspiler.ts
@@ -182,10 +182,10 @@ export class CSharpTranspiler extends BaseTranspiler {
 
         // check if it is a class declaration that we need to wrap arounf typeof
         // example: const x = Error -> var x = typeof(Error)
-        const type = global.checker.getTypeAtLocation(node);
+        const type = this.getChecker().getTypeAtLocation(node);
         const symbol = type?.symbol;
         if (symbol !== undefined) {
-            // const declarations = global.checker.getDeclaredTypeOfSymbol(symbol).symbol?.declarations ?? [];
+            // const declarations = this.getChecker().getDeclaredTypeOfSymbol(symbol).symbol?.declarations ?? [];
             const decl = symbol?.declarations ?? [];
             let isBuiltIn = undefined;
             if (decl.length > 0) {
@@ -205,7 +205,7 @@ export class CSharpTranspiler extends BaseTranspiler {
                     // const b = instance;
                     // gets transpiled to
                     // var instance = typeof(x);
-                    const symbol = global.checker.getSymbolAtLocation(node);
+                    const symbol = this.getChecker().getSymbolAtLocation(node);
                     let isClassDeclaration = false;
                     if (symbol) {
                         const first = symbol.declarations[0];
@@ -213,7 +213,7 @@ export class CSharpTranspiler extends BaseTranspiler {
                             isClassDeclaration = true;
                         }
                         if (first.kind === ts.SyntaxKind.ImportSpecifier) {
-                            const importedSymbol = global.checker.getAliasedSymbol(symbol);
+                            const importedSymbol = this.getChecker().getAliasedSymbol(symbol);
                             if (importedSymbol?.declarations[0]?.kind === ts.SyntaxKind.ClassDeclaration) {
                                 isClassDeclaration = true;
                             }
@@ -317,7 +317,7 @@ export class CSharpTranspiler extends BaseTranspiler {
     }
 
     printWrappedUnknownThisProperty(node) {
-        const type = global.checker.getResolvedSignature(node);
+        const type = this.getChecker().getResolvedSignature(node);
         if (type?.declaration === undefined) {
             let parsedArguments = node.arguments?.map((a) => this.printNode(a, 0)).join(", ");
             parsedArguments = parsedArguments ? parsedArguments : "";
@@ -440,7 +440,7 @@ export class CSharpTranspiler extends BaseTranspiler {
                 // const type = this.getType(node);
                 // const parsedType = this.getTypeFromRawType(type);
                 const leftElement = arrayBindingPatternElements[index];
-                const leftType = global.checker.getTypeAtLocation(leftElement);
+                const leftType = this.getChecker().getTypeAtLocation(leftElement);
                 const parsedType = this.getTypeFromRawType(leftType);
 
                 const castExp = parsedType ? `(${parsedType})` : "";
@@ -486,8 +486,8 @@ export class CSharpTranspiler extends BaseTranspiler {
         // x = y
         // cast y to x type when y is unknown
         // if (op === ts.SyntaxKind.EqualsToken) {
-        //     const leftType = global.checker.getTypeAtLocation(left);
-        //     const rightType = global.checker.getTypeAtLocation(right);
+        //     const leftType = this.getChecker().getTypeAtLocation(left);
+        //     const rightType = this.getChecker().getTypeAtLocation(right);
 
         //     if (this.isAnyType(rightType.flags) && !this.isAnyType(leftType.flags)) {
         //         // const parsedType = this.getTypeFromRawType(leftType);
@@ -499,8 +499,8 @@ export class CSharpTranspiler extends BaseTranspiler {
     }
 
     // castVariableAssignmentIfNeeded(left, right, identation) {
-    //     const leftType = global.checker.getTypeAtLocation(left);
-    //     const rightType = global.checker.getTypeAtLocation(right);
+    //     const leftType = this.getChecker().getTypeAtLocation(left);
+    //     const rightType = this.getChecker().getTypeAtLocation(right);
 
     //     const leftText = this.printNode(left, 0);
     //     const rightText = this.printNode(right, 0);
@@ -558,7 +558,7 @@ export class CSharpTranspiler extends BaseTranspiler {
         if (parsedValue === this.UNDEFINED_TOKEN) {
             let specificVarToken = "object";
             if (this.INFER_VAR_TYPE) {
-                const variableType = global.checker.typeToString(global.checker.getTypeAtLocation(declaration));
+                const variableType = this.getChecker().typeToString(this.getChecker().getTypeAtLocation(declaration));
                 if (this.VariableTypeReplacements[variableType]) {
                     specificVarToken = this.VariableTypeReplacements[variableType] + '?';
                 }
@@ -577,7 +577,7 @@ export class CSharpTranspiler extends BaseTranspiler {
 
         switch(rightSide) {
         case 'length':
-                const type = (global.checker as TypeChecker).getTypeAtLocation(expression); // eslint-disable-line
+                const type = (this.getChecker() as TypeChecker).getTypeAtLocation(expression); // eslint-disable-line
             this.warnIfAnyType(node, type.flags, leftSide, "length");
             // rawExpression = this.isStringType(type.flags) ? `(string${leftSide}).Length` : `(${leftSide}.Cast<object>().ToList()).Count`;
             rawExpression = this.isStringType(type.flags) ? `((string)${leftSide}).Length` : `${this.ARRAY_LENGTH_WRAPPER_OPEN}${leftSide}${this.ARRAY_LENGTH_WRAPPER_CLOSE}`; // `(${leftSide}.Cast<object>()).ToList().Count`
@@ -602,7 +602,7 @@ export class CSharpTranspiler extends BaseTranspiler {
         }
 
         // convert x: number = undefined (invalid) into x = -1 (valid)
-        if (node?.escapedText === "undefined" && global.checker.getTypeAtLocation(node?.parent)?.flags === ts.TypeFlags.Number) {
+        if (node?.escapedText === "undefined" && this.getChecker().getTypeAtLocation(node?.parent)?.flags === ts.TypeFlags.Number) {
             // return "-1";
             return this.UNDEFINED_TOKEN;
         }
@@ -726,7 +726,7 @@ export class CSharpTranspiler extends BaseTranspiler {
         if (elems.length > 0) {
             const first = elems[0];
             if (first.kind === ts.SyntaxKind.CallExpression) {
-                // const type = global.checker.getTypeAtLocation(first);
+                // const type = this.getChecker().getTypeAtLocation(first);
                 let type = this.getFunctionType(first);
                 // const parsedType = this.getTypeFromRawType(type);
                 // parsedType === "Task" ||
@@ -978,7 +978,7 @@ export class CSharpTranspiler extends BaseTranspiler {
 
     printLengthProperty(node, identation, name = undefined) {
         const leftSide = this.printNode(node.expression, 0);
-        const type = (global.checker as TypeChecker).getTypeAtLocation(node.expression); // eslint-disable-line
+        const type = (this.getChecker() as TypeChecker).getTypeAtLocation(node.expression); // eslint-disable-line
         this.warnIfAnyType(node, type.flags, leftSide, "length");
         return this.isStringType(type.flags) ? `((string)${leftSide}).Length` : `${this.ARRAY_LENGTH_WRAPPER_OPEN}${leftSide}${this.ARRAY_LENGTH_WRAPPER_CLOSE}`;
     }
@@ -1057,9 +1057,9 @@ export class CSharpTranspiler extends BaseTranspiler {
                 const id = expression.expression;
                 // JS's built-in `Error` maps to C#'s `Exception` (C# has no `Error` type in the BCL)
                 const idName = id.escapedText === 'Error' ? 'Exception' : id.escapedText;
-                const symbol = global.checker.getSymbolAtLocation(expression.expression);
+                const symbol = this.getChecker().getSymbolAtLocation(expression.expression);
                 if (symbol) {
-                    const declarations = global.checker.getDeclaredTypeOfSymbol(symbol).symbol?.declarations ?? [];
+                    const declarations = this.getChecker().getDeclaredTypeOfSymbol(symbol).symbol?.declarations ?? [];
                     const isClassDeclaration = declarations.find(l => l.kind === ts.SyntaxKind.InterfaceDeclaration ||  l.kind === ts.SyntaxKind.ClassDeclaration);
                     if (isClassDeclaration){
                         return this.getIden(identation) + `${this.THROW_TOKEN} ${this.NEW_TOKEN} ${idName} ((string)${parsedArg}) ${this.LINE_TERMINATOR}`;
@@ -1104,7 +1104,7 @@ export class CSharpTranspiler extends BaseTranspiler {
     }
 
     // printLeadingComments(node, identation) {
-    //     const fullText = global.src.getFullText();
+    //     const fullText = this.getSrc().getFullText();
     //     const commentsRangeList = ts.getLeadingCommentRanges(fullText, node.pos);
     //     const commentsRange = commentsRangeList ? commentsRangeList : undefined;
     //     let res = "";
@@ -1140,11 +1140,11 @@ export class CSharpTranspiler extends BaseTranspiler {
 // }
 
 // getTypesFromCallExpressionParameters(node) {
-//     const resolvedParams = global.checker.getResolvedSignature(node).parameters;
+//     const resolvedParams = this.getChecker().getResolvedSignature(node).parameters;
 //     const parsedTypes = [];
 //     resolvedParams.forEach((p) => {
 //         const decl = p.declarations[0];
-//         const type = global.checker.getTypeAtLocation(decl);
+//         const type = this.getChecker().getTypeAtLocation(decl);
 //         const parsedType = this.getTypeFromRawType(type);
 //         parsedTypes.push(parsedType);
 //     });

--- a/src/goTranspiler.ts
+++ b/src/goTranspiler.ts
@@ -628,7 +628,7 @@ ${this.getIden(identation)}PanicOnError(${varName})`;
     }
 
     printWrappedUnknownThisProperty(node) {
-        const type = global.checker.getResolvedSignature(node);
+        const type = this.getChecker().getResolvedSignature(node);
         if (type?.declaration === undefined) {
             let parsedArguments = node.arguments?.map((a) => this.printNode(a, 0)).join(", ");
             parsedArguments = parsedArguments ? parsedArguments : "";
@@ -905,8 +905,8 @@ ${this.getIden(identation)}PanicOnError(${varName})`;
         // x = y
         // cast y to x type when y is unknown
         // if (op === ts.SyntaxKind.EqualsToken) {
-        //     const leftType = global.checker.getTypeAtLocation(left);
-        //     const rightType = global.checker.getTypeAtLocation(right);
+        //     const leftType = this.getChecker().getTypeAtLocation(left);
+        //     const rightType = this.getChecker().getTypeAtLocation(right);
 
         //     if (this.isAnyType(rightType.flags) && !this.isAnyType(leftType.flags)) {
         //         // const parsedType = this.getTypeFromRawType(leftType);
@@ -918,8 +918,8 @@ ${this.getIden(identation)}PanicOnError(${varName})`;
     }
 
     // castVariableAssignmentIfNeeded(left, right, identation) {
-    //     const leftType = global.checker.getTypeAtLocation(left);
-    //     const rightType = global.checker.getTypeAtLocation(right);
+    //     const leftType = this.getChecker().getTypeAtLocation(left);
+    //     const rightType = this.getChecker().getTypeAtLocation(right);
 
     //     const leftText = this.printNode(left, 0);
     //     const rightText = this.printNode(right, 0);
@@ -940,7 +940,7 @@ ${this.getIden(identation)}PanicOnError(${varName})`;
 
         switch(rightSide) {
         case 'length':
-                const type = (global.checker as TypeChecker).getTypeAtLocation(expression); // eslint-disable-line
+                const type = (this.getChecker() as TypeChecker).getTypeAtLocation(expression); // eslint-disable-line
             // this.warnIfAnyType(node, type.flags, leftSide, "length");
             // rawExpression = this.isStringType(type.flags) ? `(string${leftSide}).Length` : `(${leftSide}.Cast<object>().ToList()).Count`;
             rawExpression = this.isStringType(type.flags) ? `GetLength(${leftSide})` : `${this.ARRAY_LENGTH_WRAPPER_OPEN}${leftSide}${this.ARRAY_LENGTH_WRAPPER_CLOSE}`; // `(${leftSide}.Cast<object>()).ToList().Count`
@@ -1126,7 +1126,7 @@ ${this.getIden(identation)}PanicOnError(${varName})`;
     }
 
     getLineBasedSuffix(node): string {
-        const { line, character } = global.src.getLineAndCharacterOfPosition(node.getStart());
+        const { line, character } = this.getSrc().getLineAndCharacterOfPosition(node.getStart());
         return `${line}${character}`;
     }
 
@@ -1141,7 +1141,7 @@ ${this.getIden(identation)}PanicOnError(${varName})`;
 
         const exprStm = this.printNode(node.expression, identation);
 
-        // const { line, character } = global.src.getLineAndCharacterOfPosition(node.getStart());
+        // const { line, character } = this.getSrc().getLineAndCharacterOfPosition(node.getStart());
         // console.log(`line: ${line}, character: ${character}`);
         const returnRandName = "retRes" + this.getLineBasedSuffix(node);
 
@@ -1254,7 +1254,7 @@ ${this.getIden(identation)}return nil`;
         if (elems.length > 0) {
             const first = elems[0];
             if (first.kind === ts.SyntaxKind.CallExpression) {
-                // const type = global.checker.getTypeAtLocation(first);
+                // const type = this.getChecker().getTypeAtLocation(first);
                 const type = this.getFunctionType(first);
                 // const parsedType = this.getTypeFromRawType(type);
                 // parsedType === "Task" ||
@@ -1455,7 +1455,7 @@ ${this.getIden(identation)}return nil`;
 
     printLengthProperty(node, identation, name = undefined) {
         const leftSide = this.printNode(node.expression, 0);
-        // const type = (global.checker as TypeChecker).getTypeAtLocation(node.expression); // eslint-disable-line
+        // const type = (this.getChecker() as TypeChecker).getTypeAtLocation(node.expression); // eslint-disable-line
         // this.warnIfAnyType(node, type.flags, leftSide, "length");
         return `GetLength(${leftSide})`;
     }
@@ -1520,9 +1520,9 @@ ${this.getIden(identation)}return nil`;
             if (expression.expression.kind === ts.SyntaxKind.Identifier) {
                 // handle throw new X
                 const id = expression.expression;
-                const symbol = global.checker.getSymbolAtLocation(expression.expression);
+                const symbol = this.getChecker().getSymbolAtLocation(expression.expression);
                 if (symbol) {
-                    const declarations = global.checker.getDeclaredTypeOfSymbol(symbol).symbol?.declarations ?? [];
+                    const declarations = this.getChecker().getDeclaredTypeOfSymbol(symbol).symbol?.declarations ?? [];
                     const isClassDeclaration = declarations.find(l => l.kind === ts.SyntaxKind.InterfaceDeclaration ||  l.kind === ts.SyntaxKind.ClassDeclaration);
                     if (isClassDeclaration){
                         // return this.getIden(identation) + `${this.THROW_TOKEN} ${this.NEW_TOKEN} ${id.escapedText} ((string)${parsedArg}) ${this.LINE_TERMINATOR}`;
@@ -1588,7 +1588,7 @@ ${this.getIden(identation)}return nil`;
                 // const type = this.getType(node);
                 // const parsedType = this.getTypeFromRawType(type);
                 const leftElement = arrayBindingPatternElements[index];
-                const leftType = global.checker.getTypeAtLocation(leftElement);
+                const leftType = this.getChecker().getTypeAtLocation(leftElement);
                 const parsedType = this.getTypeFromRawType(leftType);
 
                 const castExp = parsedType ? `(${parsedType})` : "";

--- a/src/javaTranspiler.ts
+++ b/src/javaTranspiler.ts
@@ -276,7 +276,7 @@ export class JavaTranspiler extends BaseTranspiler {
             node?.parent?.kind === ts.SyntaxKind.PropertyAccessExpression ||
             node?.parent?.kind === ts.SyntaxKind.ElementAccessExpression;
         if (!isLeftSide && !isCallOrPropertyAccess && !isInsideCatch && !isInsideNewExpression) {
-            const type = (global as any).checker.getTypeAtLocation(node);
+            const type = this.getChecker().getTypeAtLocation(node);
             const typeSymbol = type?.symbol;
             if (typeSymbol !== undefined) {
                 const decl = typeSymbol?.declarations ?? [];
@@ -287,7 +287,7 @@ export class JavaTranspiler extends BaseTranspiler {
                 }
 
                 if (isBuiltIn !== undefined && !isBuiltIn) {
-                    const symbol = (global as any).checker.getSymbolAtLocation(node);
+                    const symbol = this.getChecker().getSymbolAtLocation(node);
                     let isClassDeclaration = false;
                     if (symbol) {
                         const first = symbol.declarations[0];
@@ -295,7 +295,7 @@ export class JavaTranspiler extends BaseTranspiler {
                             isClassDeclaration = true;
                         }
                         if (first.kind === ts.SyntaxKind.ImportSpecifier) {
-                            const importedSymbol = (global as any).checker.getAliasedSymbol(symbol);
+                            const importedSymbol = this.getChecker().getAliasedSymbol(symbol);
                             if (
                                 importedSymbol?.declarations[0]?.kind ===
                                 ts.SyntaxKind.ClassDeclaration
@@ -422,7 +422,7 @@ export class JavaTranspiler extends BaseTranspiler {
     // }
 
     printWrappedUnknownThisProperty(node) {
-        const type = (global as any).checker.getResolvedSignature(node);
+        const type = this.getChecker().getResolvedSignature(node);
         if (type?.declaration === undefined) {
             let parsedArguments = node.arguments
                 ?.map((a) => this.printNode(a, 0))
@@ -824,7 +824,7 @@ export class JavaTranspiler extends BaseTranspiler {
         // sibling for-loops (separate `let i` declarations = separate symbols).
         const symbolIdOf = (n: any): string => {
             try {
-                const checker = (global as any).checker;
+                const checker = this.getChecker();
                 const sym = checker?.getSymbolAtLocation?.(n);
                 const decl = sym?.declarations?.[0] ?? sym?.valueDeclaration;
                 if (decl) return `s:${decl.pos}:${decl.end}`;
@@ -1292,8 +1292,8 @@ export class JavaTranspiler extends BaseTranspiler {
         if (parsedValue === this.UNDEFINED_TOKEN) {
             let specificVarToken = "Object";
             if (this.INFER_VAR_TYPE) {
-                const variableType = (global as any).checker.typeToString(
-                    (global as any).checker.getTypeAtLocation(declaration)
+                const variableType = this.getChecker().typeToString(
+                    this.getChecker().getTypeAtLocation(declaration)
                 );
                 if (this.VariableTypeReplacements[variableType]) {
                     specificVarToken = this.VariableTypeReplacements[variableType];
@@ -1343,7 +1343,7 @@ export class JavaTranspiler extends BaseTranspiler {
 
         switch (rightSide) {
         case "length": {
-            const type = (global.checker as TypeChecker).getTypeAtLocation(
+            const type = (this.getChecker() as TypeChecker).getTypeAtLocation(
                 expression
             );
             this.warnIfAnyType(node, (type as any).flags, leftSide, "length");
@@ -1375,7 +1375,7 @@ export class JavaTranspiler extends BaseTranspiler {
 
         if (
             node?.escapedText === "undefined" &&
-            (global as any).checker.getTypeAtLocation(node?.parent)?.flags ===
+            this.getChecker().getTypeAtLocation(node?.parent)?.flags ===
             ts.TypeFlags.Number
         ) {
             return this.UNDEFINED_TOKEN;
@@ -1840,7 +1840,7 @@ export class JavaTranspiler extends BaseTranspiler {
 
     printLengthProperty(node, _identation, _name = undefined) {
         const leftSide = this.printNode(node.expression, 0);
-        const type = (global.checker as TypeChecker).getTypeAtLocation(node.expression);
+        const type = (this.getChecker() as TypeChecker).getTypeAtLocation(node.expression);
         this.warnIfAnyType(node, (type as any).flags, leftSide, "length");
         return this.isStringType((type as any).flags)
             ? `((String)${leftSide}).length()`
@@ -1906,10 +1906,10 @@ export class JavaTranspiler extends BaseTranspiler {
                 // `catch (Exception e)` won't catch it. Map JS/TS `Error` to
                 // RuntimeException so standard catch blocks work.
                 const exceptionName = id.escapedText === "Error" ? "RuntimeException" : id.escapedText;
-                const symbol = (global as any).checker.getSymbolAtLocation(expression.expression);
+                const symbol = this.getChecker().getSymbolAtLocation(expression.expression);
                 if (symbol) {
                     const declarations =
-                        (global as any).checker.getDeclaredTypeOfSymbol(symbol).symbol?.declarations ?? [];
+                        this.getChecker().getDeclaredTypeOfSymbol(symbol).symbol?.declarations ?? [];
                     const isClassDeclaration = declarations.find(
                         (l) =>
                             l.kind === ts.SyntaxKind.InterfaceDeclaration ||

--- a/src/phpTranspiler.ts
+++ b/src/phpTranspiler.ts
@@ -86,7 +86,7 @@ export class PhpTranspiler extends BaseTranspiler {
         }
 
         // Get the symbol for the identifier
-        const symbol = global.checker.getSymbolAtLocation(node);
+        const symbol = this.getChecker().getSymbolAtLocation(node);
 
         // Check if the symbol references a function declaration or expression
         if (symbol && symbol.valueDeclaration) {
@@ -128,8 +128,8 @@ export class PhpTranspiler extends BaseTranspiler {
                 return TOKEN;
             }
 
-            const leftType = global.checker.getTypeAtLocation(left);
-            const rightType = global.checker.getTypeAtLocation(right);
+            const leftType = this.getChecker().getTypeAtLocation(left);
+            const rightType = this.getChecker().getTypeAtLocation(right);
 
             if (leftType.flags === ts.TypeFlags.String || rightType.flags === ts.TypeFlags.String) {
                 return TOKEN;
@@ -143,7 +143,7 @@ export class PhpTranspiler extends BaseTranspiler {
 
     printLengthProperty(node, identation, name = undefined) {
         const leftSide = this.printNode(node.expression, 0);
-        const type = (global.checker as TypeChecker).getTypeAtLocation(node.expression); // eslint-disable-line
+        const type = (this.getChecker() as TypeChecker).getTypeAtLocation(node.expression); // eslint-disable-line
         this.warnIfAnyType(node, type.flags, leftSide, "length");
         return this.isStringType(type.flags) ? `strlen(${leftSide})` : `count(${leftSide})`;
     }
@@ -228,7 +228,7 @@ export class PhpTranspiler extends BaseTranspiler {
         // "ol".includes("o") -> str_contains("ol", "o") or [12,3,4].includes(3) -> in_array(3, [12,3,4])
         const leftSide = node.expression?.expression;
         const leftSideText = this.printNode(leftSide, 0);
-        const type = global.checker.getTypeAtLocation(leftSide); // eslint-disable-line
+        const type = this.getChecker().getTypeAtLocation(leftSide); // eslint-disable-line
         this.warnIfAnyType(node, type.flags, leftSideText, "includes");
         this.warnIfAnyType(node, type.flags, leftSideText, "includes");
         if (this.isStringType(type.flags)) {
@@ -241,7 +241,7 @@ export class PhpTranspiler extends BaseTranspiler {
     printIndexOfCall(node, identation, name = undefined, parsedArg = undefined) {
         const leftSide = node.expression?.expression;
         const leftSideText = this.printNode(leftSide, 0);
-        const type = global.checker.getTypeAtLocation(leftSide); // eslint-disable-line
+        const type = this.getChecker().getTypeAtLocation(leftSide); // eslint-disable-line
         this.warnIfAnyType(node, type.flags, leftSideText, "indexOf");
         if (this.isStringType(type.flags)) {
             return `mb_strpos(${name}, ${parsedArg})`;
@@ -384,7 +384,7 @@ export class PhpTranspiler extends BaseTranspiler {
             const parsedArg =  (args && args.length > 0) ? this.printNode(args[0], 0): undefined;
             const leftSideOfIndexOf = left.expression.expression;  // myString in myString.indexOf
             const leftSide = this.printNode(leftSideOfIndexOf, 0);
-            const rightType = global.checker.getTypeAtLocation(leftSideOfIndexOf); // type of myString in myString.indexOf ("b") >= 0;
+            const rightType = this.getChecker().getTypeAtLocation(leftSideOfIndexOf); // type of myString in myString.indexOf ("b") >= 0;
             switch(prop) {
             case 'indexOf':
                 if (op === SyntaxKind.GreaterThanEqualsToken && right === '0') {

--- a/src/pythonTranspiler.ts
+++ b/src/pythonTranspiler.ts
@@ -374,7 +374,7 @@ export class PythonTranspiler extends BaseTranspiler {
             const parsedArg =  (args && args.length > 0) ? this.printNode(args[0], 0): undefined;
             const leftSideOfIndexOf = left.expression.expression;  // myString in myString.indexOf
             const leftSide = this.printNode(leftSideOfIndexOf, 0);
-            // const rightType = global.checker.getTypeAtLocation(leftSideOfIndexOf); // type of myString in myString.indexOf ("b") >= 0;
+            // const rightType = this.getChecker().getTypeAtLocation(leftSideOfIndexOf); // type of myString in myString.indexOf ("b") >= 0;
 
             switch(prop) {
             case 'indexOf':

--- a/src/rustTranspiler.ts
+++ b/src/rustTranspiler.ts
@@ -425,7 +425,7 @@ export class RustTranspiler extends BaseTranspiler {
 
     printRustFunctionType(node): string {
         try {
-            const type = global.checker.getReturnTypeOfSignature(global.checker.getSignatureFromDeclaration(node));
+            const type = this.getChecker().getReturnTypeOfSignature(this.getChecker().getSignatureFromDeclaration(node));
             if (type.flags === ts.TypeFlags.Void) {
                 return '';
             }

--- a/src/transpiler.ts
+++ b/src/transpiler.ts
@@ -6,7 +6,7 @@ import { CSharpTranspiler } from './csharpTranspiler.js';
 import * as path from "path";
 import * as fs from "fs";
 import { Logger } from './logger.js';
-import { Languages, TranspilationMode, IFileExport, IFileImport, ITranspiledFile, IInput, ITranspileContext } from './types.js';
+import { Languages, TranspilationMode, IFileExport, IFileImport, ITranspiledFile, IInput, ITranspileContext, ITranspileProgramCache } from './types.js';
 import { GoTranspiler } from './goTranspiler.js';
 import { JavaTranspiler } from './javaTranspiler.js';
 import { RustTranspiler } from './rustTranspiler.js';
@@ -111,7 +111,7 @@ function memoizeCheckerCalls(checker: ts.TypeChecker): void {
     };
 }
 
-function getProgramAndTypeCheckerFromMemory (rootDir: string, text: string, options: any = {}): [any,any,any]  {
+function getProgramAndTypeCheckerFromMemory (rootDir: string, text: string, options: any = {}, cache?: ITranspileProgramCache): [any,any,any]  {
     options = options || ts.getDefaultCompilerOptions();
     const inMemoryFilePath = path.resolve(path.join(rootDir, "__dummy-file.ts"));
     const textAst = ts.createSourceFile(inMemoryFilePath, text, options.target || ts.ScriptTarget.Latest);
@@ -123,11 +123,36 @@ function getProgramAndTypeCheckerFromMemory (rootDir: string, text: string, opti
         [globalsShimPath, shimAst],
     ]));
 
+    if (cache !== undefined) {
+        // the dummy file changes every call, but the es lib chain behind it does not:
+        // serve those from the shared cache so they are parsed once per cache
+        const originalGetSourceFile = host.getSourceFile.bind(host);
+        host.getSourceFile = (fileName, languageVersion, onError, shouldCreateNewSourceFile) => {
+            const resolved = path.resolve(fileName);
+            if (resolved === inMemoryFilePath) {
+                return textAst;
+            }
+            const cached = cache.sourceFiles.get(resolved);
+            if (cached !== undefined && !shouldCreateNewSourceFile) {
+                return cached.sourceFile;
+            }
+            const sourceFile = originalGetSourceFile(fileName, languageVersion, onError, shouldCreateNewSourceFile);
+            if (sourceFile !== undefined) {
+                cache.sourceFiles.set(resolved, { mtimeMs: 0, sourceFile });
+            }
+            return sourceFile;
+        };
+    }
+
     const program = ts.createProgram({
         options,
         rootNames: [inMemoryFilePath, globalsShimPath],
-        host
+        host,
+        oldProgram: cache?.memoryOldProgram,
     });
+    if (cache !== undefined) {
+        cache.memoryOldProgram = program;
+    }
 
     const typeChecker = program.getTypeChecker();
     memoizeCheckerCalls(typeChecker);
@@ -146,14 +171,27 @@ export default class Transpiler {
     rustTranspiler: RustTranspiler;
     // ByPath transpilation cache: parsed SourceFiles (libs + the whole import graph)
     // are reused across createProgram calls — without this every transpile*ByPath call
-    // re-parses the full import closure of the target file (~1s+ per file on big repos)
-    private byPathHost: ts.CompilerHost | undefined;
-    private byPathOldProgram: ts.Program | undefined;
-    private sourceFileCache: Map<string, { mtimeMs: number, sourceFile: ts.SourceFile }> = new Map();
+    // re-parses the full import closure of the target file (~1s+ per file on big repos).
+    // Lives in a standalone object so several Transpiler instances on the same thread
+    // can be pointed at one cache (see Transpiler.createProgramCache).
+    private programCache: ITranspileProgramCache;
     // typescript state of the transpilation in flight, shared with the language printers
     private context: ITranspileContext | undefined;
-    constructor(config = {}) {
+
+    // A program cache holds parsed typescript SourceFiles and the last program built
+    // from them. Hand the same cache to several Transpiler instances to reuse one
+    // parse/typecheck of the es lib chain and of every shared import across all of
+    // them. Callers that need isolation simply omit it and get a private cache.
+    //
+    // Same-thread only: these are live V8 objects, so a cache cannot be posted to a
+    // worker_threads isolate — give each worker its own long-lived cache instead.
+    static createProgramCache(): ITranspileProgramCache {
+        return { sourceFiles: new Map() };
+    }
+
+    constructor(config = {}, programCache?: ITranspileProgramCache) {
         this.config = config;
+        this.programCache = programCache ?? Transpiler.createProgramCache();
         const phpConfig = config["php"] || {};
         const pythonConfig = config["python"] || {};
         const csharpConfig = config["csharp"] || {};
@@ -177,8 +215,21 @@ export default class Transpiler {
         Logger.setVerboseMode(verbose);
     }
 
+    // the cache this instance parses into, to hand to further Transpiler instances
+    // that should reuse this one's parsed SourceFiles
+    getProgramCache(): ITranspileProgramCache {
+        return this.programCache;
+    }
+
+    // a second Transpiler over the same parsed typescript state, with its own
+    // printers and its own transpile context, so both can be driven independently
+    // on this thread without either clobbering the other's program
+    cloneSharingProgramCache(config = this.config): Transpiler {
+        return new Transpiler(config, this.programCache);
+    }
+
     createProgramInMemoryAndSetContext(content): ITranspileContext {
-        const [ memProgram, memType, memSource] = getProgramAndTypeCheckerFromMemory(__dirname_mock, content, fastCompilerOptions);
+        const [ memProgram, memType, memSource] = getProgramAndTypeCheckerFromMemory(__dirname_mock, content, fastCompilerOptions, this.programCache);
         return this.setContext({
             src: memSource,
             checker: memType as ts.TypeChecker,
@@ -187,10 +238,10 @@ export default class Transpiler {
     }
 
     getByPathCompilerHost(options: ts.CompilerOptions): ts.CompilerHost {
-        if (this.byPathHost === undefined) {
+        if (this.programCache.byPathHost === undefined) {
             const host = ts.createCompilerHost(options, true);
             const originalGetSourceFile = host.getSourceFile.bind(host);
-            const cache = this.sourceFileCache;
+            const cache = this.programCache.sourceFiles;
             host.getSourceFile = (fileName, languageVersion, onError, shouldCreateNewSourceFile) => {
                 let mtimeMs = 0;
                 try {
@@ -210,9 +261,9 @@ export default class Transpiler {
             };
             const shimAst = ts.createSourceFile(globalsShimPath, globalsShim, ts.ScriptTarget.Latest);
             overrideHostForVirtualFiles(host, new Map([[globalsShimPath, shimAst]]));
-            this.byPathHost = host;
+            this.programCache.byPathHost = host;
         }
-        return this.byPathHost;
+        return this.programCache.byPathHost;
     }
 
     createProgramByPathAndSetContext(path): ITranspileContext {
@@ -220,8 +271,8 @@ export default class Transpiler {
         const host = this.getByPathCompilerHost(options);
         // passing the previous program lets typescript reuse its internal state where
         // possible; the cached host makes every already-seen dependency parse-free
-        const program = ts.createProgram([path, globalsShimPath], options, host, this.byPathOldProgram);
-        this.byPathOldProgram = program;
+        const program = ts.createProgram([path, globalsShimPath], options, host, this.programCache.byPathOldProgram);
+        this.programCache.byPathOldProgram = program;
         const sourceFile = program.getSourceFile(path);
         const typeChecker = program.getTypeChecker();
         memoizeCheckerCalls(typeChecker);

--- a/src/transpiler.ts
+++ b/src/transpiler.ts
@@ -6,7 +6,7 @@ import { CSharpTranspiler } from './csharpTranspiler.js';
 import * as path from "path";
 import * as fs from "fs";
 import { Logger } from './logger.js';
-import { Languages, TranspilationMode, IFileExport, IFileImport, ITranspiledFile, IInput } from './types.js';
+import { Languages, TranspilationMode, IFileExport, IFileImport, ITranspiledFile, IInput, ITranspileContext } from './types.js';
 import { GoTranspiler } from './goTranspiler.js';
 import { JavaTranspiler } from './javaTranspiler.js';
 import { RustTranspiler } from './rustTranspiler.js';
@@ -150,6 +150,8 @@ export default class Transpiler {
     private byPathHost: ts.CompilerHost | undefined;
     private byPathOldProgram: ts.Program | undefined;
     private sourceFileCache: Map<string, { mtimeMs: number, sourceFile: ts.SourceFile }> = new Map();
+    // typescript state of the transpilation in flight, shared with the language printers
+    private context: ITranspileContext | undefined;
     constructor(config = {}) {
         this.config = config;
         const phpConfig = config["php"] || {};
@@ -175,11 +177,13 @@ export default class Transpiler {
         Logger.setVerboseMode(verbose);
     }
 
-    createProgramInMemoryAndSetGlobals(content) {
+    createProgramInMemoryAndSetContext(content): ITranspileContext {
         const [ memProgram, memType, memSource] = getProgramAndTypeCheckerFromMemory(__dirname_mock, content, fastCompilerOptions);
-        global.src = memSource;
-        global.checker = memType as ts.TypeChecker;
-        global.program = memProgram;
+        return this.setContext({
+            src: memSource,
+            checker: memType as ts.TypeChecker,
+            program: memProgram,
+        });
     }
 
     getByPathCompilerHost(options: ts.CompilerOptions): ts.CompilerHost {
@@ -211,7 +215,7 @@ export default class Transpiler {
         return this.byPathHost;
     }
 
-    createProgramByPathAndSetGlobals(path) {
+    createProgramByPathAndSetContext(path): ITranspileContext {
         const options: ts.CompilerOptions = fastCompilerOptions;
         const host = this.getByPathCompilerHost(options);
         // passing the previous program lets typescript reuse its internal state where
@@ -222,13 +226,46 @@ export default class Transpiler {
         const typeChecker = program.getTypeChecker();
         memoizeCheckerCalls(typeChecker);
 
-        global.src = sourceFile;
-        global.checker = typeChecker;
-        global.program = program;
+        return this.setContext({
+            src: sourceFile,
+            checker: typeChecker,
+            program,
+        });
     }
 
-    checkFileDiagnostics() {
-        const diagnostics = ts.getPreEmitDiagnostics(global.program, global.src);
+    // the language printers read the typescript state (source file, checker, program)
+    // off the context handed to them here, so two Transpiler instances never share
+    // state and a nested transpile can restore whatever its caller was working on
+    setContext(context: ITranspileContext): ITranspileContext {
+        this.context = context;
+        this.pythonTranspiler.setContext(context);
+        this.phpTranspiler.setContext(context);
+        this.csharpTranspiler.setContext(context);
+        this.goTranspiler.setContext(context);
+        this.javaTranspiler.setContext(context);
+        this.rustTranspiler.setContext(context);
+        return context;
+    }
+
+    getContext(): ITranspileContext {
+        if (this.context === undefined) {
+            throw new Error("No transpilation context set: the typescript program must be created before transpiling.");
+        }
+        return this.context;
+    }
+
+    /** @deprecated renamed to createProgramInMemoryAndSetContext */
+    createProgramInMemoryAndSetGlobals(content): ITranspileContext {
+        return this.createProgramInMemoryAndSetContext(content);
+    }
+
+    /** @deprecated renamed to createProgramByPathAndSetContext */
+    createProgramByPathAndSetGlobals(path): ITranspileContext {
+        return this.createProgramByPathAndSetContext(path);
+    }
+
+    checkFileDiagnostics(context: ITranspileContext = this.getContext()) {
+        const diagnostics = ts.getPreEmitDiagnostics(context.program, context.src);
         if (diagnostics.length > 0) {
             let errorMessage = "Errors found in the typescript code. Transpilation might produce invalid results:\n";
             diagnostics.forEach( msg => {
@@ -238,53 +275,55 @@ export default class Transpiler {
         }
     }
 
-    transpile(lang: Languages, mode: TranspilationMode, file: string, sync = false, setGlobals = true, handleImports = true): ITranspiledFile {
+    transpile(lang: Languages, mode: TranspilationMode, file: string, sync = false, createContext = true, handleImports = true): ITranspiledFile {
         // improve this logic later
-        if (setGlobals) {
+        if (createContext) {
             if (mode === TranspilationMode.ByPath) {
-                this.createProgramByPathAndSetGlobals(file);
+                this.createProgramByPathAndSetContext(file);
             } else {
-                this.createProgramInMemoryAndSetGlobals(file);
+                this.createProgramInMemoryAndSetContext(file);
             }
 
             // check for warnings and errors
             this.checkFileDiagnostics();
         }
 
+        const src = this.getContext().src;
+
         let transpiledContent = undefined;
         switch(lang) {
         case Languages.Python:
             this.pythonTranspiler.asyncTranspiling = !sync;
-            transpiledContent = this.pythonTranspiler.printNode(global.src, -1);
+            transpiledContent = this.pythonTranspiler.printNode(src, -1);
             this.pythonTranspiler.asyncTranspiling = true; // reset to default
             break;
         case Languages.Php:
             this.phpTranspiler.asyncTranspiling = !sync;
-            transpiledContent = this.phpTranspiler.printNode(global.src, -1);
+            transpiledContent = this.phpTranspiler.printNode(src, -1);
             this.phpTranspiler.asyncTranspiling = true; // reset to default
             break;
         case Languages.CSharp:
-            transpiledContent = this.csharpTranspiler.printNode(global.src, -1);
+            transpiledContent = this.csharpTranspiler.printNode(src, -1);
             break;
         case Languages.Go:
-            transpiledContent = this.goTranspiler.printNode(global.src, -1);
+            transpiledContent = this.goTranspiler.printNode(src, -1);
             break;
         case Languages.Java:
-            transpiledContent = this.javaTranspiler.printNode(global.src, -1);
+            transpiledContent = this.javaTranspiler.printNode(src, -1);
             break;
         case Languages.Rust:
-            transpiledContent = this.rustTranspiler.printNode(global.src, -1);
+            transpiledContent = this.rustTranspiler.printNode(src, -1);
             break;
         }
         let imports = [];
         let exports = [];
 
         if (handleImports) {
-            imports = this.pythonTranspiler.getFileImports(global.src);
-            exports = this.pythonTranspiler.getFileExports(global.src);
+            imports = this.pythonTranspiler.getFileImports(src);
+            exports = this.pythonTranspiler.getFileExports(src);
         }
 
-        const methodsTypes = this.pythonTranspiler.getMethodTypes(global.src);
+        const methodsTypes = this.pythonTranspiler.getMethodTypes(src);
         Logger.success("transpilation finished successfully");
 
         return {
@@ -296,14 +335,15 @@ export default class Transpiler {
     }
 
     transpileDifferentLanguagesGeneric(mode: TranspilationMode, input: IInput[], content: string): ITranspiledFile[] {
+        let context: ITranspileContext;
         if (mode === TranspilationMode.ByPath) {
-            this.createProgramByPathAndSetGlobals(content);
+            context = this.createProgramByPathAndSetContext(content);
         } else {
-            this.createProgramInMemoryAndSetGlobals(content);
+            context = this.createProgramInMemoryAndSetContext(content);
         }
 
         // check for warnings and errors
-        this.checkFileDiagnostics();
+        this.checkFileDiagnostics(context);
 
         const files = [];
         input.forEach( (inp) => {
@@ -314,10 +354,10 @@ export default class Transpiler {
             });
         });
 
-        const methodsTypes = this.pythonTranspiler.getMethodTypes(global.src);
+        const methodsTypes = this.pythonTranspiler.getMethodTypes(context.src);
 
-        const imports = this.pythonTranspiler.getFileImports(global.src);
-        const exports = this.pythonTranspiler.getFileExports(global.src);
+        const imports = this.pythonTranspiler.getFileImports(context.src);
+        const exports = this.pythonTranspiler.getFileExports(context.src);
 
         const output =  files.map( (file) => {
             return {
@@ -401,13 +441,13 @@ export default class Transpiler {
 
 
     getFileImports(content: string): IFileImport[] {
-        this.createProgramInMemoryAndSetGlobals(content);
-        return this.phpTranspiler.getFileImports(global.src);
+        const context = this.createProgramInMemoryAndSetContext(content);
+        return this.phpTranspiler.getFileImports(context.src);
     }
 
     getFileExports(content: string): IFileExport[] {
-        this.createProgramInMemoryAndSetGlobals(content);
-        return this.phpTranspiler.getFileExports(global.src);
+        const context = this.createProgramInMemoryAndSetContext(content);
+        return this.phpTranspiler.getFileExports(context.src);
     }
 
     setPHPPropResolution(props: string[]) {

--- a/src/transpiler.ts
+++ b/src/transpiler.ts
@@ -247,13 +247,6 @@ export default class Transpiler {
         return context;
     }
 
-    getContext(): ITranspileContext {
-        if (this.context === undefined) {
-            throw new Error("No transpilation context set: the typescript program must be created before transpiling.");
-        }
-        return this.context;
-    }
-
     /** @deprecated renamed to createProgramInMemoryAndSetContext */
     createProgramInMemoryAndSetGlobals(content): ITranspileContext {
         return this.createProgramInMemoryAndSetContext(content);
@@ -264,7 +257,7 @@ export default class Transpiler {
         return this.createProgramByPathAndSetContext(path);
     }
 
-    checkFileDiagnostics(context: ITranspileContext = this.getContext()) {
+    checkFileDiagnostics(context: ITranspileContext = this.context) {
         const diagnostics = ts.getPreEmitDiagnostics(context.program, context.src);
         if (diagnostics.length > 0) {
             let errorMessage = "Errors found in the typescript code. Transpilation might produce invalid results:\n";
@@ -288,7 +281,7 @@ export default class Transpiler {
             this.checkFileDiagnostics();
         }
 
-        const src = this.getContext().src;
+        const src = this.context.src;
 
         let transpiledContent = undefined;
         switch(lang) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,18 @@ interface ITranspileContext {
     program: ts.Program;
 }
 
+// Parsed SourceFiles (the es lib chain plus the import closure of everything
+// transpiled so far) and the last program built from them, so the next program
+// reuses that work instead of re-parsing it. Shareable between Transpiler
+// instances running on the same thread; these are plain V8 heap objects, so a
+// worker_threads isolate cannot receive one and needs a cache of its own.
+interface ITranspileProgramCache {
+    sourceFiles: Map<string, { mtimeMs: number, sourceFile: ts.SourceFile }>;
+    byPathHost?: ts.CompilerHost;
+    byPathOldProgram?: ts.Program;
+    memoryOldProgram?: ts.Program;
+}
+
 
 interface IParameterType {
     name: string;
@@ -96,6 +108,7 @@ export {
     ITranspiledFile,
     IFileExport,
     ITranspileContext,
+    ITranspileProgramCache,
     TranspilationError,
     // FunctionReturnTypeError,
     // FunctionArgumentTypeError,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,17 @@
+import ts from 'typescript';
 
 interface IInput {
     language: Languages;
     async: boolean;
+}
+
+// per-transpile typescript state. Holding it in an explicit object (owned by the
+// Transpiler instance and handed to the language printers) instead of process
+// globals keeps concurrent/nested transpilations from clobbering each other.
+interface ITranspileContext {
+    src: ts.SourceFile;
+    checker: ts.TypeChecker;
+    program: ts.Program;
 }
 
 
@@ -85,6 +95,7 @@ export {
     IFileImport,
     ITranspiledFile,
     IFileExport,
+    ITranspileContext,
     TranspilationError,
     // FunctionReturnTypeError,
     // FunctionArgumentTypeError,

--- a/tests/sharedProgramCache.test.ts
+++ b/tests/sharedProgramCache.test.ts
@@ -1,0 +1,103 @@
+import { Transpiler } from '../src/transpiler';
+
+const config = {
+    'verbose': false,
+    'python': {
+        'parser': {
+            'NUM_LINES_END_FILE': 0
+        }
+    }
+};
+
+describe('shared program cache', () => {
+    test('instances given the same cache share it, instances without one do not', () => {
+        const cache = Transpiler.createProgramCache();
+        const a = new Transpiler(config, cache);
+        const b = new Transpiler(config, cache);
+        const isolated = new Transpiler(config);
+
+        expect(a.getProgramCache()).toBe(cache);
+        expect(b.getProgramCache()).toBe(cache);
+        expect(isolated.getProgramCache()).not.toBe(cache);
+    });
+
+    test('cloneSharingProgramCache shares the cache but not the transpile context', () => {
+        const a = new Transpiler(config);
+        const b = a.cloneSharingProgramCache();
+
+        expect(b).not.toBe(a);
+        expect(b.getProgramCache()).toBe(a.getProgramCache());
+
+        // both are driven independently: b creates its program between a's program
+        // creation and a's printing, which must not disturb a
+        const aContext = (a as any).createProgramInMemoryAndSetContext("const alpha = 1;");
+        const bContext = (b as any).createProgramInMemoryAndSetContext("const beta = 2;");
+
+        expect(aContext.src).not.toBe(bContext.src);
+        expect((a as any).context.src).toBe(aContext.src);
+        expect((b as any).context.src).toBe(bContext.src);
+        expect(a.transpilePython("const alpha = 1;").content).toBe("alpha = 1");
+        expect(b.transpilePython("const beta = 2;").content).toBe("beta = 2");
+    });
+
+    test('a shared cache reuses parsed lib SourceFiles across instances', () => {
+        const cache = Transpiler.createProgramCache();
+        const a = new Transpiler(config, cache);
+        a.transpilePython("const x = 1;");
+        const parsedAfterFirst = cache.sourceFiles.size;
+        expect(parsedAfterFirst).toBeGreaterThan(0);
+
+        // a second instance on the same cache must not re-parse the lib chain
+        const b = new Transpiler(config, cache);
+        const bContext = (b as any).createProgramInMemoryAndSetContext("const y = 2;");
+        expect(cache.sourceFiles.size).toBe(parsedAfterFirst);
+
+        const libName = [ ...cache.sourceFiles.keys() ].find((f) => f.includes("lib.esnext"));
+        expect(libName).toBeDefined();
+        expect(bContext.program.getSourceFile(libName)).toBe(cache.sourceFiles.get(libName).sourceFile);
+    });
+
+    test('sharing a cache does not change transpilation output', () => {
+        const source = "const x = 1;\nconst y = 'a';";
+        const isolated = new Transpiler(config).transpilePython(source).content;
+
+        const cache = Transpiler.createProgramCache();
+        const first = new Transpiler(config, cache);
+        const second = new Transpiler(config, cache);
+        // interleave two live instances over one cache
+        first.transpilePython("const noise = 0;");
+        expect(second.transpilePython(source).content).toBe(isolated);
+        expect(first.transpilePython(source).content).toBe(isolated);
+    });
+
+    test('interleaved transpiles over one cache keep each instance on its own program', () => {
+        const cache = Transpiler.createProgramCache();
+        const a = new Transpiler(config, cache);
+        const b = new Transpiler(config, cache);
+
+        const aContext = (a as any).createProgramInMemoryAndSetContext("const alpha: string = 'a'; alpha;");
+        const bContext = (b as any).createProgramInMemoryAndSetContext("const beta: number = 1; beta;");
+
+        expect(aContext.program).not.toBe(bContext.program);
+        // a's checker must still resolve a's types after b built a program from the
+        // same cache (typescript's oldProgram reuse must not invalidate it)
+        const aExpr = (aContext.src.statements[1] as any).expression;
+        const bExpr = (bContext.src.statements[1] as any).expression;
+        expect(aContext.checker.typeToString(aContext.checker.getTypeAtLocation(aExpr))).toBe("string");
+        expect(bContext.checker.typeToString(bContext.checker.getTypeAtLocation(bExpr))).toBe("number");
+    });
+
+    test('concurrent async transpiles over one shared cache all produce correct output', async () => {
+        const cache = Transpiler.createProgramCache();
+        const sources = [ "const a = 1;", "const b = 2;", "const c = 3;", "const d = 4;" ];
+        const expected = [ "a = 1", "b = 2", "c = 3", "d = 4" ];
+
+        // one instance per unit of work, all sharing the parsed lib chain
+        const results = await Promise.all(sources.map(async (source) => {
+            const transpiler = new Transpiler(config, cache);
+            return transpiler.transpilePython(source).content;
+        }));
+
+        expect(results).toEqual(expected);
+    });
+});

--- a/tests/transpileContext.test.ts
+++ b/tests/transpileContext.test.ts
@@ -29,8 +29,8 @@ describe('transpile context isolation', () => {
         const bContext = (b as any).createProgramInMemoryAndSetContext("const beta = 2;");
 
         expect(aContext.src).not.toBe(bContext.src);
-        expect((a as any).getContext().src).toBe(aContext.src);
-        expect((b as any).getContext().src).toBe(bContext.src);
+        expect((a as any).context.src).toBe(aContext.src);
+        expect((b as any).context.src).toBe(bContext.src);
         expect((a as any).pythonTranspiler.getSrc()).toBe(aContext.src);
         expect((b as any).pythonTranspiler.getSrc()).toBe(bContext.src);
 
@@ -44,7 +44,7 @@ describe('transpile context isolation', () => {
 
         const printers = [ 'pythonTranspiler', 'phpTranspiler', 'csharpTranspiler', 'goTranspiler', 'javaTranspiler', 'rustTranspiler' ];
         printers.forEach((printer) => {
-            expect((transpiler as any)[printer].getContext()).toBe(context);
+            expect((transpiler as any)[printer].context).toBe(context);
             expect((transpiler as any)[printer].getChecker()).toBe(context.checker);
             expect((transpiler as any)[printer].getProgram()).toBe(context.program);
         });
@@ -52,7 +52,7 @@ describe('transpile context isolation', () => {
 
     test('printing without a context throws instead of reading stale state', () => {
         const transpiler = new Transpiler(config);
-        expect(() => (transpiler as any).getContext()).toThrow(/No transpilation context set/);
+        expect((transpiler as any).context).toBeUndefined();
         expect(() => (transpiler as any).goTranspiler.getChecker()).toThrow(/No transpilation context set/);
     });
 

--- a/tests/transpileContext.test.ts
+++ b/tests/transpileContext.test.ts
@@ -1,0 +1,68 @@
+import { Transpiler } from '../src/transpiler';
+
+const config = {
+    'verbose': false,
+    'python': {
+        'parser': {
+            'NUM_LINES_END_FILE': 0
+        }
+    }
+};
+
+describe('transpile context isolation', () => {
+    test('does not write the typescript state to process globals', () => {
+        const transpiler = new Transpiler(config);
+        transpiler.transpilePython("const x = 1;");
+
+        expect((global as any).src).toBeUndefined();
+        expect((global as any).checker).toBeUndefined();
+        expect((global as any).program).toBeUndefined();
+    });
+
+    test('two instances keep their own context', () => {
+        const a = new Transpiler(config);
+        const b = new Transpiler(config);
+
+        // interleave: b creates its own program between a's program creation and a's
+        // printing, which used to clobber a's source file through the process globals
+        const aContext = (a as any).createProgramInMemoryAndSetContext("const alpha = 1;");
+        const bContext = (b as any).createProgramInMemoryAndSetContext("const beta = 2;");
+
+        expect(aContext.src).not.toBe(bContext.src);
+        expect((a as any).getContext().src).toBe(aContext.src);
+        expect((b as any).getContext().src).toBe(bContext.src);
+        expect((a as any).pythonTranspiler.getSrc()).toBe(aContext.src);
+        expect((b as any).pythonTranspiler.getSrc()).toBe(bContext.src);
+
+        expect(a.transpilePython("const alpha = 1;").content).toBe("alpha = 1");
+        expect(b.transpilePython("const beta = 2;").content).toBe("beta = 2");
+    });
+
+    test('every language printer shares the context of its transpiler', () => {
+        const transpiler = new Transpiler(config);
+        const context = (transpiler as any).createProgramInMemoryAndSetContext("const x = 1;");
+
+        const printers = [ 'pythonTranspiler', 'phpTranspiler', 'csharpTranspiler', 'goTranspiler', 'javaTranspiler', 'rustTranspiler' ];
+        printers.forEach((printer) => {
+            expect((transpiler as any)[printer].getContext()).toBe(context);
+            expect((transpiler as any)[printer].getChecker()).toBe(context.checker);
+            expect((transpiler as any)[printer].getProgram()).toBe(context.program);
+        });
+    });
+
+    test('printing without a context throws instead of reading stale state', () => {
+        const transpiler = new Transpiler(config);
+        expect(() => (transpiler as any).getContext()).toThrow(/No transpilation context set/);
+        expect(() => (transpiler as any).goTranspiler.getChecker()).toThrow(/No transpilation context set/);
+    });
+
+    test('sequential transpilations of different sources do not leak into each other', () => {
+        const transpiler = new Transpiler(config);
+
+        const first = transpiler.transpilePython("const first = 1;").content;
+        const second = transpiler.transpilePython("const second = 2;").content;
+
+        expect(first).toBe("first = 1");
+        expect(second).toBe("second = 2");
+    });
+});

--- a/worker.ts
+++ b/worker.ts
@@ -1,5 +1,10 @@
 import { Transpiler } from './src/transpiler.js'
 
+// one cache per worker thread, reused by every task this worker handles: a
+// ts.Program cannot cross the isolate boundary, but the parse work it needs can
+// at least be done once per worker instead of once per task
+const programCache = Transpiler.createProgramCache();
+
 // expected files config
 // const filesConfig = [
 //     {
@@ -13,7 +18,7 @@ import { Transpiler } from './src/transpiler.js'
 // ];
 
 export default async ({transpilerConfig, filesConfig}) => {
-    const transpiler = new Transpiler(transpilerConfig);
+    const transpiler = new Transpiler(transpilerConfig, programCache);
 
     const result = [] as any[];
     for (const fileConfig of filesConfig) {


### PR DESCRIPTION
## Problem

The typescript `SourceFile`, `TypeChecker` and `Program` are stored on the node `global` object:

```ts
global.src = sourceFile;
global.checker = typeChecker;
global.program = program;
```

and read back from ~96 call sites across `baseTranspiler.ts` and the six language printers (`global.checker.getTypeAtLocation(...)`, `global.src.getFullText()`, ...).

Because that state is process-wide, **two `Transpiler` instances cannot be used at the same time**. The second `createProgram*` call overwrites the state the first one is still printing against, so the first transpilation silently resolves types against the wrong source file. That also rules out running several transpilations concurrently in one process, which is the natural way to speed up large multi-language builds.

## Change

The state now lives in an explicit per-transpile context instead:

```ts
interface ITranspileContext {
    src: ts.SourceFile;
    checker: ts.TypeChecker;
    program: ts.Program;
}
```

- `Transpiler` owns the context of the transpilation in flight and hands it to every language printer via `setContext`.
- `BaseTranspiler` holds it in `this.context` and exposes `getSrc()` / `getChecker()` / `getProgram()`. All ~96 `global.*` reads became `this.getChecker()` / `this.getSrc()` / `this.getProgram()`, so each printer reads its own instance state.
- `createProgramInMemoryAndSetGlobals` / `createProgramByPathAndSetGlobals` become `...AndSetContext` and return the context they built. The old names stay as thin deprecated forwarders so no external caller breaks.
- `transpile(...)`'s `setGlobals` parameter is renamed to `createContext` (same position, same semantics).
- Reading the context before a program exists now throws a clear error instead of dereferencing whatever the previous transpilation left behind.

After this change `global.src`, `global.checker` and `global.program` are never written or read — a `Transpiler` instance is self-contained.

## Compatibility

Public API is unchanged. `transpileGoByPath`, `transpilePython`, `transpileDifferentLanguagesByPath`, `getFileImports`, `getFileExports` and friends keep their signatures, so ccxt and other consumers need no call-site changes.

## Verification

- `npm test` — **369 passed, 9 suites** (364 pre-existing + 5 new)
- `npm run build` (lint + tsup) — passes, **0 eslint errors**
- `npx tsc --noEmit` — clean

**Output is byte-for-byte identical.** I transpiled `tests/integration/source/transpilable.ts` on `master` and on this branch and diffed the results: all 6 languages, both `ByPath` and `ByContent` modes, plus `getFileImports` / `getFileExports` / `methodsTypes` — no differences.

```
$ diff -r base new && echo IDENTICAL
IDENTICAL
```

`npm run integration` was also run; it only fails locally at the rust step because `cargo` is not installed in this environment (`code: 127`), unrelated to this change.

New `tests/transpileContext.test.ts` covers what the refactor buys:

- `global.src` / `global.checker` / `global.program` stay `undefined` after a transpile
- two `Transpiler` instances that interleave program creation keep their own context and both produce correct output (this is the case that was broken before)
- every language printer sees the context of its owning transpiler
- using a printer with no context throws instead of reading stale state

## Sharing a program between threads

The follow-up question was whether a `ts.Program` can be shared between threads. **It cannot**, and that is a hard limit rather than a missing feature. Each worker thread is a separate V8 isolate and `postMessage` uses structured clone. Measured against `typescript` directly:

```
postMessage(ts.Program):             FAILED -> DataCloneError: () => rootNames could not be cloned
postMessage(ts.TypeChecker):         FAILED -> DataCloneError: ... could not be cloned
postMessage(ts.SourceFile):          FAILED -> DataCloneError: ... could not be cloned
postMessage(SourceFile.statements[0]): FAILED -> DataCloneError: ... could not be cloned
```

A `SharedArrayBuffer` only shares raw bytes, so it cannot hold a `Program` either. Anything that claims to share one across isolates is really rebuilding it on the other side.

What *can* be shared is the work behind the program, so this PR now does that.

### `ITranspileProgramCache`

The parsed `SourceFile`s (the es lib chain plus the import closure seen so far) and the last program built from them move out of the `Transpiler` instance into a standalone cache:

```ts
const cache = Transpiler.createProgramCache();

const a = new Transpiler(config, cache);
const b = new Transpiler(config, cache); // reuses everything a has parsed
const c = a.cloneSharingProgramCache();  // same, from an existing instance
```

- the constructor's second argument is optional — omitting it keeps the current behaviour of a private cache per instance, so nothing changes for existing callers
- `getProgramCache()` / `cloneSharingProgramCache()` point further instances at an existing cache
- the in-memory path uses the cache too, so repeated `transpileX(content)` calls no longer re-parse the lib chain every time

Each instance keeps its own printers and its own transpile context, so instances over one cache can be interleaved without clobbering each other — that is exactly what the context refactor above makes safe.

### For worker pools

The cache is per thread, not per process: each worker keeps its own long-lived cache and the pool ships file paths as it does today. `worker.ts` now holds a module-level cache, so parse work happens once per worker instead of once per task.

On 30 ccxt source files in that shape (a fresh `Transpiler` per 5-file task, as a Piscina worker does):

```
per-task instance (today): 4528 ms  (150.9 ms/file)
shared program cache     : 2881 ms  ( 96.0 ms/file)   1.57x
```

### Verification

- `npm test` — **375 passed, 10 suites** (369 + 6 new in `tests/sharedProgramCache.test.ts`)
- output is unchanged: transpiled with isolated instances vs. a shared cache vs. interleaved clones, across all six languages, both modes, plus `getFileImports` / `getFileExports` / `methodsTypes` — byte for byte identical
- typescript's `oldProgram` reuse does not invalidate a live program: a checker still resolves its own types after another instance built a program from the same cache (covered by a test)

Caches are same-thread only, and that is documented in the README next to the worker example.
