### PR TITLE
fix(java): wrap bare rethrows of checked exceptions

### DIFF
--- a/src/javaTranspiler.ts
+++ b/src/javaTranspiler.ts
@@ -1954,12 +1954,14 @@ export class JavaTranspiler extends BaseTranspiler {
 
     printThrowStatement(node, identation) {
         if (node.expression.kind === ts.SyntaxKind.Identifier) {
+            // a bare rethrow (`throw e`) of a caught java.lang.Exception is a checked
+            // exception, which the surrounding async lambdas cannot declare - keep
+            // unchecked exceptions (ccxt errors extend RuntimeException) as-is and
+            // wrap checked ones, preserving the original as the cause
+            const name = this.printNode(node.expression, 0);
             return (
                 this.getIden(identation) +
-                this.THROW_TOKEN +
-                " " +
-                this.printNode(node.expression, 0) +
-                this.LINE_TERMINATOR
+                `${this.THROW_TOKEN} (${name} instanceof RuntimeException ? (RuntimeException)${name} : new RuntimeException(${name}))${this.LINE_TERMINATOR}`
             );
         }
         if (node.expression.kind === ts.SyntaxKind.NewExpression) {


### PR DESCRIPTION
## What broke

`printThrowStatement`'s Identifier branch emits a bare rethrow (`throw e`) verbatim. In the transpiled ccxt Java, method bodies live inside `CompletableFuture` lambdas which cannot declare `throws`, so rethrowing the caught (checked) `java.lang.Exception` fails compilation:

```
error: unreported exception Exception; must be caught or declared to be thrown
    try { ... } catch (Exception e) { throw e; }
                                      ^
```

First real-world trigger: the mexc ws `authenticate` fix (ccxt/ccxt#29392) — the first bare rethrow ever transpiled to Java in ccxt — whose auto-committed emission broke ccxt's `java.yml` Build Project step ([failing run](https://github.com/ccxt/ccxt/actions/runs/30665329897/job/91270882439)).

## Fix

Emit a conditional wrap in the Identifier branch:

```java
throw (e instanceof RuntimeException ? (RuntimeException)e : new RuntimeException(e));
```

- unchecked exceptions — including all ccxt error types, which extend `RuntimeException` — rethrow with identity intact, so upstream `catch` dispatch on ccxt exception types is unaffected
- genuinely checked exceptions get wrapped with the original as the `cause`
- other language emitters untouched (their targets accept bare rethrow)

## Verified against ccxt

- patched emitter → regenerated `java/lib/.../pro/MexcCore.java` → emits the conditional form at the previously-broken site
- isolated javac proof: the wrapped construct compiles inside a `supplyAsync` lambda; the previous emission reproduces the exact CI error
