### PR TITLE
fix(java): drop one trailing null/undefined argument on this-calls

### DIFF
--- a/src/javaTranspiler.ts
+++ b/src/javaTranspiler.ts
@@ -69,6 +69,30 @@ const parserConfig = {
 };
 
 export class JavaTranspiler extends BaseTranspiler {
+
+    printArgsForCallExpression(node, identation) {
+        let args: readonly any[] = node.arguments ?? [];
+        const callee = node.expression;
+        const isThisCall = callee?.kind === ts.SyntaxKind.PropertyAccessExpression
+            && callee.expression?.kind === ts.SyntaxKind.ThisKeyword;
+        if (isThisCall && args.length > 0) {
+            const last = args[args.length - 1];
+            const isNullish = last.kind === ts.SyntaxKind.NullKeyword
+                || (last.kind === ts.SyntaxKind.Identifier && last.escapedText === 'undefined');
+            if (isNullish) {
+                // drop exactly one trailing null/undefined argument: the generated java
+                // surface is uniformly (required..., Object... optionals), and a bare
+                // trailing null is ambiguous to javac ("non-varargs call of varargs
+                // method with inexact argument type for last parameter"). Omission is
+                // behaviorally identical - both Helpers.getArg and SafeMethods.opt
+                // treat a null varargs array and an empty one the same, see
+                // https://github.com/ccxt/ccxt/pull/29617 for the warning inventory
+                args = args.slice(0, -1);
+            }
+        }
+        return args.map((a) => this.printNode(a, identation).trim()).join(", ");
+    }
+
     binaryExpressionsWrappers;
 
     varListFromObjectLiterals = {};

--- a/tests/javaTranspiler.test.ts
+++ b/tests/javaTranspiler.test.ts
@@ -2293,3 +2293,56 @@ describe('java transpiling tests', () => {
         expect(soloB).not.toMatch(/final Object finalRequest/);
     });
 });
+
+describe('trailing null/undefined omission on this-calls (varargs ambiguity)', () => {
+    // the generated java surface is uniformly varargs - a trailing bare null
+    // triggers javac's "non-varargs call of varargs method" warning; the
+    // transpiler drops exactly one trailing null/undefined on this.-calls
+    const classWrap = (body: string) =>
+        "class T {\n" +
+        "    safeString2(o, k1, k2, d = undefined) { return undefined; }\n" +
+        "    safeValue(o, k, d = undefined) { return undefined; }\n" +
+        "    parseOrders(orders, market = undefined, since = undefined, limit = undefined) { return undefined; }\n" +
+        "    handleParamString2(p, n1, n2, d = undefined) { return undefined; }\n" +
+        "    method(a, b = undefined) { return undefined; }\n" +
+        body +
+        "}";
+
+    test('drops trailing undefined on safe-family and parse helpers', () => {
+        const input = classWrap(
+            "    test() {\n" +
+            "        const a = this.safeString2({}, 'x', 'y', undefined);\n" +
+            "        const b = this.safeValue({}, 'x', undefined);\n" +
+            "        const c = this.parseOrders([], undefined);\n" +
+            "        const d = this.handleParamString2({}, 'x', 'y', undefined);\n" +
+            "    }\n");
+        const output = transpiler.transpileJava(input).content;
+        expect(output).toContain('this.safeString2(new java.util.HashMap<String, Object>() {{}}, "x", "y")');
+        expect(output).not.toContain('safeString2(new java.util.HashMap<String, Object>() {{}}, "x", "y", null)');
+        expect(output).toContain('this.safeValue(new java.util.HashMap<String, Object>() {{}}, "x")');
+        expect(output).toContain('this.parseOrders(new java.util.ArrayList<Object>(java.util.Arrays.asList()))');
+        expect(output).toContain('this.handleParamString2(new java.util.HashMap<String, Object>() {{}}, "x", "y")');
+    });
+
+    test('drops only one trailing nullish and leaves interior nulls intact', () => {
+        const input = classWrap(
+            "    test() {\n" +
+            "        this.method(undefined, undefined);\n" +
+            "    }\n");
+        const output = transpiler.transpileJava(input).content;
+        expect(output).toContain('this.method(null)');
+        expect(output).not.toContain('this.method(null, null)');
+    });
+
+    test('non-this calls keep trailing null', () => {
+        const input =
+            "function f(a, b = undefined) { return a; }\n" +
+            "class T {\n" +
+            "    test() {\n" +
+            "        f('x', undefined);\n" +
+            "    }\n" +
+            "}";
+        const output = transpiler.transpileJava(input).content;
+        expect(output).toContain('f("x", null)');
+    });
+});


### PR DESCRIPTION
Fixes the `non-varargs call of varargs method with inexact argument type for last parameter` javac warning class in ccxt's generated Java cores — 8 sites inventoried in https://github.com/ccxt/ccxt/pull/29617 (PacificaCore ×2, pro/HyperliquidCore, BitfinexCore, prediction/LimitlessCore, prediction/HyperliquidCore ×2, ZebpayCore); the ninth (hand-written example) was fixed directly in https://github.com/ccxt/ccxt/pull/29681.

**Mechanism**: the generated Java surface is uniformly `(required..., Object... optionals)` — 364 varargs signatures in `BaseExchange.java` — so a transpiled `this.method(..., undefined)` emits a bare trailing `null` that javac can't disambiguate between one-null-argument and null-varargs-array.

**Fix**: a Java-scoped `printArgsForCallExpression` override (slot was free — no prior java override) drops exactly one trailing `NullKeyword`/`undefined` argument when the receiver is `this`. Design notes:
- **Omission over casting**: behaviorally identical by proof — both terminal varargs readers on the ccxt java side (`Helpers.getArg`: `v == null || v.length <= index → def`; `SafeMethods.opt`: `dv == null || dv.length == 0 → null`) treat a null array and an empty array the same, so `f(x, null)` ≡ `f(x)` at runtime today.
- **Single-drop, not greedy**: bounds the blast radius; the pathological case (explicit `undefined` into a required trailing param) fails loudly at `:lib:compileJava`, never silently.
- **Interior nulls and non-this calls untouched**; the implicit-API path is structurally unaffected (`printWrappedUnknownThisProperty` packs an explicit `Object[]` and never had the ambiguity).

**Tests**: 3 new cases (safe-family + parse + handleParam shapes, single-drop/interior-null preservation, non-this negative). Full java suite 100/100; cross-language suites python+cs 93/93, php+go 72/72 — zero regressions.

Follow-up on the ccxt side after the version bump: verify zero warnings in a clean `:lib:compileJava`, then consider `-Werror` on the category so the class can't regrow.